### PR TITLE
Compare project with Claude Code library

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,301 @@
+/**
+ * Hooks 系统
+ * 支持在工具调用前后执行自定义脚本
+ */
+
+import { spawn } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
+
+export type HookEvent =
+  | 'PreToolUse'
+  | 'PostToolUse'
+  | 'PrePromptSubmit'
+  | 'PostPromptSubmit'
+  | 'Notification'
+  | 'Stop';
+
+export interface HookConfig {
+  /** 事件类型 */
+  event: HookEvent;
+  /** 匹配条件（工具名或正则） */
+  matcher?: string;
+  /** 执行的命令 */
+  command: string;
+  /** 命令参数 */
+  args?: string[];
+  /** 超时时间（毫秒） */
+  timeout?: number;
+  /** 环境变量 */
+  env?: Record<string, string>;
+  /** 是否阻塞（等待完成） */
+  blocking?: boolean;
+}
+
+export interface HookInput {
+  event: HookEvent;
+  toolName?: string;
+  toolInput?: unknown;
+  toolOutput?: string;
+  message?: string;
+  sessionId?: string;
+}
+
+export interface HookResult {
+  success: boolean;
+  output?: string;
+  error?: string;
+  blocked?: boolean;
+  blockMessage?: string;
+}
+
+// 已注册的 hooks
+const registeredHooks: HookConfig[] = [];
+
+/**
+ * 注册 hook
+ */
+export function registerHook(config: HookConfig): void {
+  registeredHooks.push(config);
+}
+
+/**
+ * 从配置文件加载 hooks
+ */
+export function loadHooksFromFile(configPath: string): void {
+  if (!fs.existsSync(configPath)) return;
+
+  try {
+    const content = fs.readFileSync(configPath, 'utf-8');
+    const config = JSON.parse(content);
+
+    if (config.hooks && Array.isArray(config.hooks)) {
+      for (const hook of config.hooks) {
+        registerHook(hook);
+      }
+    }
+  } catch (err) {
+    console.error(`Failed to load hooks from ${configPath}:`, err);
+  }
+}
+
+/**
+ * 从项目目录加载 hooks
+ */
+export function loadProjectHooks(projectDir: string): void {
+  // 检查 .claude/settings.json
+  const settingsPath = path.join(projectDir, '.claude', 'settings.json');
+  loadHooksFromFile(settingsPath);
+
+  // 检查 .claude/hooks/ 目录
+  const hooksDir = path.join(projectDir, '.claude', 'hooks');
+  if (fs.existsSync(hooksDir) && fs.statSync(hooksDir).isDirectory()) {
+    const files = fs.readdirSync(hooksDir);
+    for (const file of files) {
+      if (file.endsWith('.json')) {
+        loadHooksFromFile(path.join(hooksDir, file));
+      }
+    }
+  }
+}
+
+/**
+ * 获取匹配的 hooks
+ */
+function getMatchingHooks(event: HookEvent, toolName?: string): HookConfig[] {
+  return registeredHooks.filter((hook) => {
+    if (hook.event !== event) return false;
+
+    if (hook.matcher && toolName) {
+      // 支持正则匹配
+      if (hook.matcher.startsWith('/') && hook.matcher.endsWith('/')) {
+        const regex = new RegExp(hook.matcher.slice(1, -1));
+        return regex.test(toolName);
+      }
+      // 精确匹配
+      return hook.matcher === toolName;
+    }
+
+    return true;
+  });
+}
+
+/**
+ * 执行单个 hook
+ */
+async function executeHook(hook: HookConfig, input: HookInput): Promise<HookResult> {
+  return new Promise((resolve) => {
+    const timeout = hook.timeout || 30000;
+    let stdout = '';
+    let stderr = '';
+
+    // 准备环境变量
+    const env = {
+      ...process.env,
+      ...hook.env,
+      CLAUDE_HOOK_EVENT: input.event,
+      CLAUDE_HOOK_TOOL_NAME: input.toolName || '',
+      CLAUDE_HOOK_SESSION_ID: input.sessionId || '',
+    };
+
+    // 通过 stdin 传递输入
+    const inputJson = JSON.stringify({
+      event: input.event,
+      toolName: input.toolName,
+      toolInput: input.toolInput,
+      toolOutput: input.toolOutput,
+      message: input.message,
+    });
+
+    const proc = spawn(hook.command, hook.args || [], {
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const timeoutId = setTimeout(() => {
+      proc.kill('SIGKILL');
+      resolve({
+        success: false,
+        error: 'Hook execution timed out',
+      });
+    }, timeout);
+
+    proc.stdin?.write(inputJson);
+    proc.stdin?.end();
+
+    proc.stdout?.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr?.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    proc.on('close', (code) => {
+      clearTimeout(timeoutId);
+
+      // 检查是否阻塞
+      if (code !== 0) {
+        // 尝试解析 JSON 输出以获取阻塞消息
+        try {
+          const output = JSON.parse(stdout);
+          if (output.blocked) {
+            resolve({
+              success: false,
+              blocked: true,
+              blockMessage: output.message || 'Blocked by hook',
+            });
+            return;
+          }
+        } catch {
+          // 非 JSON 输出
+        }
+
+        resolve({
+          success: false,
+          error: stderr || `Hook exited with code ${code}`,
+        });
+        return;
+      }
+
+      resolve({
+        success: true,
+        output: stdout,
+      });
+    });
+
+    proc.on('error', (err) => {
+      clearTimeout(timeoutId);
+      resolve({
+        success: false,
+        error: err.message,
+      });
+    });
+  });
+}
+
+/**
+ * 运行所有匹配的 hooks
+ */
+export async function runHooks(input: HookInput): Promise<HookResult[]> {
+  const matchingHooks = getMatchingHooks(input.event, input.toolName);
+  const results: HookResult[] = [];
+
+  for (const hook of matchingHooks) {
+    const result = await executeHook(hook, input);
+    results.push(result);
+
+    // 如果 hook 阻塞且是 blocking 类型，停止执行后续 hooks
+    if (result.blocked && hook.blocking) {
+      break;
+    }
+  }
+
+  return results;
+}
+
+/**
+ * 检查是否有任何 hook 阻塞操作
+ */
+export function isBlocked(results: HookResult[]): { blocked: boolean; message?: string } {
+  for (const result of results) {
+    if (result.blocked) {
+      return { blocked: true, message: result.blockMessage };
+    }
+  }
+  return { blocked: false };
+}
+
+/**
+ * PreToolUse hook 辅助函数
+ */
+export async function runPreToolUseHooks(
+  toolName: string,
+  toolInput: unknown,
+  sessionId?: string
+): Promise<{ allowed: boolean; message?: string }> {
+  const results = await runHooks({
+    event: 'PreToolUse',
+    toolName,
+    toolInput,
+    sessionId,
+  });
+
+  const blockCheck = isBlocked(results);
+  return {
+    allowed: !blockCheck.blocked,
+    message: blockCheck.message,
+  };
+}
+
+/**
+ * PostToolUse hook 辅助函数
+ */
+export async function runPostToolUseHooks(
+  toolName: string,
+  toolInput: unknown,
+  toolOutput: string,
+  sessionId?: string
+): Promise<void> {
+  await runHooks({
+    event: 'PostToolUse',
+    toolName,
+    toolInput,
+    toolOutput,
+    sessionId,
+  });
+}
+
+/**
+ * 清除所有已注册的 hooks
+ */
+export function clearHooks(): void {
+  registeredHooks.length = 0;
+}
+
+/**
+ * 获取已注册的 hooks 数量
+ */
+export function getHookCount(): number {
+  return registeredHooks.length;
+}

--- a/src/tools/ask.ts
+++ b/src/tools/ask.ts
@@ -1,0 +1,162 @@
+/**
+ * AskUserQuestion 工具
+ * 向用户提出问题并获取选择
+ */
+
+import * as readline from 'readline';
+import chalk from 'chalk';
+import { BaseTool } from './base.js';
+import type { AskUserQuestionInput, ToolResult, ToolDefinition } from '../types/index.js';
+
+export class AskUserQuestionTool extends BaseTool<AskUserQuestionInput, ToolResult> {
+  name = 'AskUserQuestion';
+  description = `Ask the user a question with predefined options to clarify requirements or get approval.
+
+Use this tool when you need to:
+- Clarify ambiguous requirements
+- Get user approval for a specific approach
+- Ask about implementation preferences
+- Confirm understanding of a task
+
+Each question should have 2-4 options. An "Other" option allowing free-form input is automatically provided.`;
+
+  getInputSchema(): ToolDefinition['inputSchema'] {
+    return {
+      type: 'object',
+      properties: {
+        questions: {
+          type: 'array',
+          description: 'Questions to ask the user (1-4 questions)',
+          items: {
+            type: 'object',
+            properties: {
+              question: {
+                type: 'string',
+                description: 'The complete question to ask the user',
+              },
+              header: {
+                type: 'string',
+                description: 'Short label displayed as a chip/tag (max 12 chars)',
+              },
+              options: {
+                type: 'array',
+                description: 'The available choices (2-4 options)',
+                items: {
+                  type: 'object',
+                  properties: {
+                    label: {
+                      type: 'string',
+                      description: 'Display text for this option (1-5 words)',
+                    },
+                    description: {
+                      type: 'string',
+                      description: 'Explanation of what this option means',
+                    },
+                  },
+                  required: ['label', 'description'],
+                },
+              },
+              multiSelect: {
+                type: 'boolean',
+                description: 'Allow multiple selections',
+              },
+            },
+            required: ['question', 'header', 'options', 'multiSelect'],
+          },
+        },
+      },
+      required: ['questions'],
+    };
+  }
+
+  async execute(input: AskUserQuestionInput): Promise<ToolResult> {
+    const { questions } = input;
+
+    if (!questions || questions.length === 0) {
+      return { success: false, error: 'No questions provided' };
+    }
+
+    if (questions.length > 4) {
+      return { success: false, error: 'Maximum 4 questions allowed' };
+    }
+
+    const answers: Record<string, string> = {};
+
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+
+    const askQuestion = (prompt: string): Promise<string> => {
+      return new Promise((resolve) => {
+        rl.question(prompt, (answer) => {
+          resolve(answer.trim());
+        });
+      });
+    };
+
+    try {
+      for (let i = 0; i < questions.length; i++) {
+        const q = questions[i];
+
+        console.log(chalk.bold(`\n[${q.header}] ${q.question}`));
+        console.log();
+
+        // 显示选项
+        q.options.forEach((opt, idx) => {
+          console.log(chalk.cyan(`  ${idx + 1}. ${opt.label}`));
+          console.log(chalk.gray(`     ${opt.description}`));
+        });
+        console.log(chalk.yellow(`  ${q.options.length + 1}. Other (enter custom response)`));
+        console.log();
+
+        const response = await askQuestion(
+          q.multiSelect
+            ? chalk.blue('Enter choices (comma-separated numbers): ')
+            : chalk.blue('Enter your choice (number): ')
+        );
+
+        // 解析响应
+        if (q.multiSelect) {
+          const indices = response.split(',').map((s) => parseInt(s.trim(), 10));
+          const selected: string[] = [];
+
+          for (const idx of indices) {
+            if (idx >= 1 && idx <= q.options.length) {
+              selected.push(q.options[idx - 1].label);
+            } else if (idx === q.options.length + 1) {
+              const custom = await askQuestion(chalk.blue('Enter custom response: '));
+              selected.push(custom);
+            }
+          }
+
+          answers[q.header] = selected.join(', ');
+        } else {
+          const idx = parseInt(response, 10);
+
+          if (idx >= 1 && idx <= q.options.length) {
+            answers[q.header] = q.options[idx - 1].label;
+          } else if (idx === q.options.length + 1) {
+            const custom = await askQuestion(chalk.blue('Enter custom response: '));
+            answers[q.header] = custom;
+          } else {
+            answers[q.header] = response; // 直接使用输入
+          }
+        }
+      }
+    } finally {
+      rl.close();
+    }
+
+    // 格式化答案输出
+    let output = 'User Responses:\n';
+    for (const [header, answer] of Object.entries(answers)) {
+      output += `  ${header}: ${answer}\n`;
+    }
+
+    return {
+      success: true,
+      output,
+    };
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -10,6 +10,11 @@ export * from './search.js';
 export * from './web.js';
 export * from './todo.js';
 export * from './agent.js';
+export * from './notebook.js';
+export * from './planmode.js';
+export * from './mcp.js';
+export * from './ask.js';
+export * from './sandbox.js';
 
 import { toolRegistry } from './base.js';
 import { BashTool, BashOutputTool, KillShellTool } from './bash.js';
@@ -18,22 +23,51 @@ import { GlobTool, GrepTool } from './search.js';
 import { WebFetchTool, WebSearchTool } from './web.js';
 import { TodoWriteTool } from './todo.js';
 import { AgentTool, TaskOutputTool } from './agent.js';
+import { NotebookEditTool } from './notebook.js';
+import { EnterPlanModeTool, ExitPlanModeTool } from './planmode.js';
+import { ListMcpResourcesTool, ReadMcpResourceTool } from './mcp.js';
+import { AskUserQuestionTool } from './ask.js';
 
 // 注册所有工具
 export function registerAllTools(): void {
+  // Bash 工具
   toolRegistry.register(new BashTool());
   toolRegistry.register(new BashOutputTool());
   toolRegistry.register(new KillShellTool());
+
+  // 文件工具
   toolRegistry.register(new FileReadTool());
   toolRegistry.register(new FileWriteTool());
   toolRegistry.register(new FileEditTool());
+
+  // 搜索工具
   toolRegistry.register(new GlobTool());
   toolRegistry.register(new GrepTool());
+
+  // Web 工具
   toolRegistry.register(new WebFetchTool());
   toolRegistry.register(new WebSearchTool());
+
+  // 任务管理
   toolRegistry.register(new TodoWriteTool());
+
+  // 代理工具
   toolRegistry.register(new AgentTool());
   toolRegistry.register(new TaskOutputTool());
+
+  // Notebook 编辑
+  toolRegistry.register(new NotebookEditTool());
+
+  // 计划模式
+  toolRegistry.register(new EnterPlanModeTool());
+  toolRegistry.register(new ExitPlanModeTool());
+
+  // MCP 工具
+  toolRegistry.register(new ListMcpResourcesTool());
+  toolRegistry.register(new ReadMcpResourceTool());
+
+  // 用户交互
+  toolRegistry.register(new AskUserQuestionTool());
 }
 
 // 自动注册

--- a/src/tools/mcp.ts
+++ b/src/tools/mcp.ts
@@ -1,0 +1,418 @@
+/**
+ * MCP (Model Context Protocol) 工具
+ * 支持连接和调用 MCP 服务器
+ */
+
+import { spawn, ChildProcess } from 'child_process';
+import { BaseTool } from './base.js';
+import type {
+  McpInput,
+  ListMcpResourcesInput,
+  ReadMcpResourceInput,
+  McpServerConfig,
+  ToolResult,
+  ToolDefinition,
+} from '../types/index.js';
+
+// MCP 服务器状态管理
+interface McpServerState {
+  config: McpServerConfig;
+  process?: ChildProcess;
+  connected: boolean;
+  capabilities: {
+    tools?: boolean;
+    resources?: boolean;
+    prompts?: boolean;
+  };
+  tools: McpToolDefinition[];
+  resources: McpResource[];
+}
+
+interface McpToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+interface McpResource {
+  uri: string;
+  name: string;
+  description?: string;
+  mimeType?: string;
+}
+
+interface McpMessage {
+  jsonrpc: '2.0';
+  id?: number;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+const mcpServers: Map<string, McpServerState> = new Map();
+let messageId = 1;
+
+/**
+ * 注册 MCP 服务器配置
+ */
+export function registerMcpServer(name: string, config: McpServerConfig): void {
+  mcpServers.set(name, {
+    config,
+    connected: false,
+    capabilities: {},
+    tools: [],
+    resources: [],
+  });
+}
+
+/**
+ * 获取所有已注册的 MCP 服务器
+ */
+export function getMcpServers(): Map<string, McpServerState> {
+  return mcpServers;
+}
+
+/**
+ * 连接到 MCP 服务器
+ */
+async function connectMcpServer(name: string): Promise<boolean> {
+  const server = mcpServers.get(name);
+  if (!server) return false;
+
+  if (server.connected && server.process) {
+    return true;
+  }
+
+  const { config } = server;
+
+  if (config.type === 'stdio' && config.command) {
+    try {
+      const proc = spawn(config.command, config.args || [], {
+        env: { ...process.env, ...config.env },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      server.process = proc;
+
+      // 发送初始化消息
+      const initResult = await sendMcpMessage(name, 'initialize', {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: {
+          name: 'claude-code-restored',
+          version: '2.0.76',
+        },
+      });
+
+      if (initResult) {
+        server.connected = true;
+        server.capabilities = initResult.capabilities || {};
+
+        // 发送 initialized 通知
+        await sendMcpNotification(name, 'notifications/initialized', {});
+
+        // 获取工具列表
+        if (server.capabilities.tools) {
+          const toolsResult = await sendMcpMessage(name, 'tools/list', {});
+          if (toolsResult?.tools) {
+            server.tools = toolsResult.tools;
+          }
+        }
+
+        // 获取资源列表
+        if (server.capabilities.resources) {
+          const resourcesResult = await sendMcpMessage(name, 'resources/list', {});
+          if (resourcesResult?.resources) {
+            server.resources = resourcesResult.resources;
+          }
+        }
+
+        return true;
+      }
+    } catch (err) {
+      console.error(`Failed to connect to MCP server ${name}:`, err);
+    }
+  }
+
+  return false;
+}
+
+/**
+ * 发送 MCP 消息并等待响应
+ */
+async function sendMcpMessage(
+  serverName: string,
+  method: string,
+  params: unknown
+): Promise<unknown | null> {
+  const server = mcpServers.get(serverName);
+  if (!server?.process?.stdin || !server.process.stdout) {
+    return null;
+  }
+
+  const id = messageId++;
+  const message: McpMessage = {
+    jsonrpc: '2.0',
+    id,
+    method,
+    params,
+  };
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      resolve(null);
+    }, 30000);
+
+    const onData = (data: Buffer) => {
+      try {
+        const lines = data.toString().split('\n').filter(Boolean);
+        for (const line of lines) {
+          const response: McpMessage = JSON.parse(line);
+          if (response.id === id) {
+            clearTimeout(timeout);
+            server.process?.stdout?.removeListener('data', onData);
+
+            if (response.error) {
+              resolve(null);
+            } else {
+              resolve(response.result);
+            }
+            return;
+          }
+        }
+      } catch {
+        // Ignore parse errors
+      }
+    };
+
+    server.process!.stdout!.on('data', onData);
+    server.process!.stdin!.write(JSON.stringify(message) + '\n');
+  });
+}
+
+/**
+ * 发送 MCP 通知（无响应）
+ */
+async function sendMcpNotification(
+  serverName: string,
+  method: string,
+  params: unknown
+): Promise<void> {
+  const server = mcpServers.get(serverName);
+  if (!server?.process?.stdin) {
+    return;
+  }
+
+  const message: McpMessage = {
+    jsonrpc: '2.0',
+    method,
+    params,
+  };
+
+  server.process.stdin.write(JSON.stringify(message) + '\n');
+}
+
+/**
+ * 调用 MCP 工具
+ */
+export async function callMcpTool(
+  serverName: string,
+  toolName: string,
+  args: unknown
+): Promise<ToolResult> {
+  const server = mcpServers.get(serverName);
+  if (!server) {
+    return { success: false, error: `MCP server not found: ${serverName}` };
+  }
+
+  if (!server.connected) {
+    const connected = await connectMcpServer(serverName);
+    if (!connected) {
+      return { success: false, error: `Failed to connect to MCP server: ${serverName}` };
+    }
+  }
+
+  const result = await sendMcpMessage(serverName, 'tools/call', {
+    name: toolName,
+    arguments: args,
+  });
+
+  if (!result) {
+    return { success: false, error: 'MCP tool call failed' };
+  }
+
+  // 解析结果
+  const content = (result as { content?: Array<{ type: string; text?: string }> }).content;
+  if (content && Array.isArray(content)) {
+    const textContent = content
+      .filter((c) => c.type === 'text')
+      .map((c) => c.text || '')
+      .join('\n');
+
+    return { success: true, output: textContent };
+  }
+
+  return { success: true, output: JSON.stringify(result) };
+}
+
+// ============ MCP 工具类 ============
+
+export class ListMcpResourcesTool extends BaseTool<ListMcpResourcesInput, ToolResult> {
+  name = 'ListMcpResources';
+  description = `List available resources from MCP servers.
+
+Resources are data sources that MCP servers can provide, such as files, database records, or API responses.`;
+
+  getInputSchema(): ToolDefinition['inputSchema'] {
+    return {
+      type: 'object',
+      properties: {
+        server: {
+          type: 'string',
+          description: 'Optional server name to filter resources by',
+        },
+      },
+      required: [],
+    };
+  }
+
+  async execute(input: ListMcpResourcesInput): Promise<ToolResult> {
+    const { server } = input;
+
+    const results: Array<{ server: string; resources: McpResource[] }> = [];
+
+    for (const [name, state] of mcpServers) {
+      if (server && name !== server) continue;
+
+      if (!state.connected) {
+        await connectMcpServer(name);
+      }
+
+      if (state.resources.length > 0) {
+        results.push({ server: name, resources: state.resources });
+      }
+    }
+
+    if (results.length === 0) {
+      return { success: true, output: 'No MCP resources available.' };
+    }
+
+    let output = 'Available MCP Resources:\n\n';
+    for (const { server: serverName, resources } of results) {
+      output += `Server: ${serverName}\n`;
+      for (const resource of resources) {
+        output += `  - ${resource.name} (${resource.uri})\n`;
+        if (resource.description) {
+          output += `    ${resource.description}\n`;
+        }
+      }
+      output += '\n';
+    }
+
+    return { success: true, output };
+  }
+}
+
+export class ReadMcpResourceTool extends BaseTool<ReadMcpResourceInput, ToolResult> {
+  name = 'ReadMcpResource';
+  description = `Read a resource from an MCP server.
+
+Resources are data sources provided by MCP servers. Use ListMcpResources first to see available resources.`;
+
+  getInputSchema(): ToolDefinition['inputSchema'] {
+    return {
+      type: 'object',
+      properties: {
+        server: {
+          type: 'string',
+          description: 'The MCP server name',
+        },
+        uri: {
+          type: 'string',
+          description: 'The resource URI to read',
+        },
+      },
+      required: ['server', 'uri'],
+    };
+  }
+
+  async execute(input: ReadMcpResourceInput): Promise<ToolResult> {
+    const { server, uri } = input;
+
+    const serverState = mcpServers.get(server);
+    if (!serverState) {
+      return { success: false, error: `MCP server not found: ${server}` };
+    }
+
+    if (!serverState.connected) {
+      const connected = await connectMcpServer(server);
+      if (!connected) {
+        return { success: false, error: `Failed to connect to MCP server: ${server}` };
+      }
+    }
+
+    const result = await sendMcpMessage(server, 'resources/read', { uri });
+
+    if (!result) {
+      return { success: false, error: 'Failed to read MCP resource' };
+    }
+
+    // 解析结果
+    const contents = (result as { contents?: Array<{ uri: string; text?: string; blob?: string }> }).contents;
+    if (contents && Array.isArray(contents)) {
+      const textContent = contents
+        .map((c) => c.text || (c.blob ? `[Binary data: ${c.blob.length} bytes]` : ''))
+        .join('\n');
+
+      return { success: true, output: textContent };
+    }
+
+    return { success: true, output: JSON.stringify(result) };
+  }
+}
+
+export class McpTool extends BaseTool<McpInput, ToolResult> {
+  private serverName: string;
+  private toolName: string;
+  private toolDescription: string;
+  private toolInputSchema: Record<string, unknown>;
+
+  constructor(serverName: string, toolDef: McpToolDefinition) {
+    super();
+    this.serverName = serverName;
+    this.toolName = toolDef.name;
+    this.toolDescription = toolDef.description;
+    this.toolInputSchema = toolDef.inputSchema;
+  }
+
+  get name(): string {
+    return `mcp__${this.serverName}__${this.toolName}`;
+  }
+
+  get description(): string {
+    return this.toolDescription;
+  }
+
+  getInputSchema(): ToolDefinition['inputSchema'] {
+    return this.toolInputSchema as ToolDefinition['inputSchema'];
+  }
+
+  async execute(input: McpInput): Promise<ToolResult> {
+    return callMcpTool(this.serverName, this.toolName, input);
+  }
+}
+
+/**
+ * 创建 MCP 服务器的所有工具
+ */
+export async function createMcpTools(serverName: string): Promise<McpTool[]> {
+  const server = mcpServers.get(serverName);
+  if (!server) return [];
+
+  if (!server.connected) {
+    await connectMcpServer(serverName);
+  }
+
+  return server.tools.map((tool) => new McpTool(serverName, tool));
+}

--- a/src/tools/notebook.ts
+++ b/src/tools/notebook.ts
@@ -1,0 +1,202 @@
+/**
+ * NotebookEdit 工具
+ * 编辑 Jupyter Notebook 单元格
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { BaseTool } from './base.js';
+import type { NotebookEditInput, ToolResult, ToolDefinition } from '../types/index.js';
+
+interface NotebookCell {
+  id?: string;
+  cell_type: 'code' | 'markdown' | 'raw';
+  source: string | string[];
+  metadata?: Record<string, unknown>;
+  outputs?: unknown[];
+  execution_count?: number | null;
+}
+
+interface NotebookContent {
+  cells: NotebookCell[];
+  metadata: Record<string, unknown>;
+  nbformat: number;
+  nbformat_minor: number;
+}
+
+export class NotebookEditTool extends BaseTool<NotebookEditInput, ToolResult> {
+  name = 'NotebookEdit';
+  description = `Completely replaces the contents of a specific cell in a Jupyter notebook (.ipynb file) with new source.
+
+Jupyter notebooks are interactive documents that combine code, text, and visualizations, commonly used for data analysis and scientific computing.
+
+Usage:
+- The notebook_path parameter must be an absolute path
+- The cell_id is used to identify which cell to edit (0-indexed if not specified)
+- Use edit_mode=insert to add a new cell at the index specified by cell_id
+- Use edit_mode=delete to delete the cell at the index specified by cell_id
+- cell_type defaults to the current cell type, required for insert mode`;
+
+  getInputSchema(): ToolDefinition['inputSchema'] {
+    return {
+      type: 'object',
+      properties: {
+        notebook_path: {
+          type: 'string',
+          description: 'The absolute path to the Jupyter notebook file to edit',
+        },
+        cell_id: {
+          type: 'string',
+          description: 'The ID of the cell to edit. When inserting, the new cell will be inserted after this cell.',
+        },
+        new_source: {
+          type: 'string',
+          description: 'The new source for the cell',
+        },
+        cell_type: {
+          type: 'string',
+          enum: ['code', 'markdown'],
+          description: 'The type of the cell (code or markdown). Required for insert mode.',
+        },
+        edit_mode: {
+          type: 'string',
+          enum: ['replace', 'insert', 'delete'],
+          description: 'The type of edit to make. Defaults to replace.',
+        },
+      },
+      required: ['notebook_path', 'new_source'],
+    };
+  }
+
+  async execute(input: NotebookEditInput): Promise<ToolResult> {
+    const { notebook_path, cell_id, new_source, cell_type, edit_mode = 'replace' } = input;
+
+    try {
+      // 检查文件是否存在
+      if (!fs.existsSync(notebook_path)) {
+        return { success: false, error: `Notebook not found: ${notebook_path}` };
+      }
+
+      // 检查文件扩展名
+      if (!notebook_path.endsWith('.ipynb')) {
+        return { success: false, error: 'File must be a Jupyter notebook (.ipynb)' };
+      }
+
+      // 读取 notebook
+      const content = fs.readFileSync(notebook_path, 'utf-8');
+      let notebook: NotebookContent;
+
+      try {
+        notebook = JSON.parse(content);
+      } catch {
+        return { success: false, error: 'Invalid notebook format' };
+      }
+
+      if (!notebook.cells || !Array.isArray(notebook.cells)) {
+        return { success: false, error: 'Invalid notebook structure: missing cells array' };
+      }
+
+      // 找到目标单元格
+      let cellIndex = -1;
+      if (cell_id !== undefined) {
+        // 尝试按 ID 查找
+        cellIndex = notebook.cells.findIndex((c, idx) =>
+          c.id === cell_id || idx.toString() === cell_id
+        );
+
+        if (cellIndex === -1) {
+          // 尝试解析为数字索引
+          const numIndex = parseInt(cell_id, 10);
+          if (!isNaN(numIndex) && numIndex >= 0 && numIndex < notebook.cells.length) {
+            cellIndex = numIndex;
+          }
+        }
+      } else {
+        cellIndex = 0; // 默认第一个单元格
+      }
+
+      // 执行编辑操作
+      switch (edit_mode) {
+        case 'replace': {
+          if (cellIndex < 0 || cellIndex >= notebook.cells.length) {
+            return { success: false, error: `Cell not found: ${cell_id}` };
+          }
+
+          const cell = notebook.cells[cellIndex];
+          cell.source = new_source.split('\n').map((line, i, arr) =>
+            i < arr.length - 1 ? line + '\n' : line
+          );
+
+          if (cell_type) {
+            cell.cell_type = cell_type;
+          }
+
+          // 清除输出（对于 code 单元格）
+          if (cell.cell_type === 'code') {
+            cell.outputs = [];
+            cell.execution_count = null;
+          }
+          break;
+        }
+
+        case 'insert': {
+          if (!cell_type) {
+            return { success: false, error: 'cell_type is required for insert mode' };
+          }
+
+          const newCell: NotebookCell = {
+            cell_type,
+            source: new_source.split('\n').map((line, i, arr) =>
+              i < arr.length - 1 ? line + '\n' : line
+            ),
+            metadata: {},
+          };
+
+          if (cell_type === 'code') {
+            newCell.outputs = [];
+            newCell.execution_count = null;
+          }
+
+          // 生成唯一 ID
+          newCell.id = this.generateCellId();
+
+          // 插入位置
+          const insertIndex = cellIndex >= 0 ? cellIndex + 1 : notebook.cells.length;
+          notebook.cells.splice(insertIndex, 0, newCell);
+          break;
+        }
+
+        case 'delete': {
+          if (cellIndex < 0 || cellIndex >= notebook.cells.length) {
+            return { success: false, error: `Cell not found: ${cell_id}` };
+          }
+
+          notebook.cells.splice(cellIndex, 1);
+          break;
+        }
+
+        default:
+          return { success: false, error: `Invalid edit_mode: ${edit_mode}` };
+      }
+
+      // 写回文件
+      fs.writeFileSync(notebook_path, JSON.stringify(notebook, null, 1), 'utf-8');
+
+      return {
+        success: true,
+        output: `Successfully ${edit_mode}d cell in ${path.basename(notebook_path)}`,
+      };
+    } catch (err) {
+      return { success: false, error: `Error editing notebook: ${err}` };
+    }
+  }
+
+  private generateCellId(): string {
+    const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+    let id = '';
+    for (let i = 0; i < 8; i++) {
+      id += chars[Math.floor(Math.random() * chars.length)];
+    }
+    return id;
+  }
+}

--- a/src/tools/planmode.ts
+++ b/src/tools/planmode.ts
@@ -1,0 +1,134 @@
+/**
+ * 计划模式工具
+ * EnterPlanMode 和 ExitPlanMode
+ */
+
+import { BaseTool } from './base.js';
+import type { ToolResult, ToolDefinition, ExitPlanModeInput } from '../types/index.js';
+
+// 计划模式状态管理
+let planModeActive = false;
+let currentPlanFile: string | null = null;
+
+export function isPlanModeActive(): boolean {
+  return planModeActive;
+}
+
+export function getPlanFile(): string | null {
+  return currentPlanFile;
+}
+
+export function setPlanMode(active: boolean, planFile?: string): void {
+  planModeActive = active;
+  currentPlanFile = planFile || null;
+}
+
+export class EnterPlanModeTool extends BaseTool<Record<string, unknown>, ToolResult> {
+  name = 'EnterPlanMode';
+  description = `Use this tool when you encounter a complex task that requires careful planning and exploration before implementation.
+
+## When to Use This Tool
+
+Use EnterPlanMode when ANY of these conditions apply:
+
+1. **Multiple Valid Approaches**: The task can be solved in several different ways, each with trade-offs
+2. **Significant Architectural Decisions**: The task requires choosing between architectural patterns
+3. **Large-Scale Changes**: The task touches many files or systems
+4. **Unclear Requirements**: You need to explore before understanding the full scope
+5. **User Input Needed**: You'll need to ask clarifying questions before starting
+
+## When NOT to Use This Tool
+
+Do NOT use EnterPlanMode for:
+- Simple, straightforward tasks with obvious implementation
+- Small bug fixes where the solution is clear
+- Adding a single function or small feature
+- Tasks you're already confident how to implement
+- Research-only tasks
+
+## What Happens in Plan Mode
+
+In plan mode, you'll:
+1. Thoroughly explore the codebase using Glob, Grep, and Read tools
+2. Understand existing patterns and architecture
+3. Design an implementation approach
+4. Present your plan to the user for approval
+5. Exit plan mode with ExitPlanMode when ready to implement`;
+
+  getInputSchema(): ToolDefinition['inputSchema'] {
+    return {
+      type: 'object',
+      properties: {},
+      required: [],
+    };
+  }
+
+  async execute(_input: Record<string, unknown>): Promise<ToolResult> {
+    if (planModeActive) {
+      return {
+        success: false,
+        error: 'Already in plan mode. Use ExitPlanMode to exit first.',
+      };
+    }
+
+    planModeActive = true;
+
+    return {
+      success: true,
+      output: `Entered plan mode.
+
+You are now in planning mode. In this mode:
+- Explore the codebase thoroughly using Read, Glob, and Grep tools
+- Understand existing patterns and architecture
+- Design your implementation approach
+- Write your plan to a file
+- Use ExitPlanMode when ready for user approval
+
+Focus on understanding the problem before proposing solutions.`,
+    };
+  }
+}
+
+export class ExitPlanModeTool extends BaseTool<ExitPlanModeInput, ToolResult> {
+  name = 'ExitPlanMode';
+  description = `Use this tool when you are in plan mode and have finished writing your plan to the plan file and are ready for user approval.
+
+## How This Tool Works
+- You should have already written your plan to the plan file
+- This tool signals that you're done planning and ready for the user to review and approve
+- The user will see the contents of your plan file when they review it
+
+## When to Use This Tool
+IMPORTANT: Only use this tool when the task requires planning the implementation steps of a task that requires writing code.
+
+## Handling Ambiguity in Plans
+Before using this tool, ensure your plan is clear and unambiguous.`;
+
+  getInputSchema(): ToolDefinition['inputSchema'] {
+    return {
+      type: 'object',
+      properties: {},
+      required: [],
+    };
+  }
+
+  async execute(_input: ExitPlanModeInput): Promise<ToolResult> {
+    if (!planModeActive) {
+      return {
+        success: false,
+        error: 'Not in plan mode. Use EnterPlanMode first.',
+      };
+    }
+
+    planModeActive = false;
+    const planFile = currentPlanFile;
+    currentPlanFile = null;
+
+    return {
+      success: true,
+      output: planFile
+        ? `Exited plan mode. Plan file: ${planFile}\n\nAwaiting user approval to proceed with implementation.`
+        : `Exited plan mode. Awaiting user approval to proceed with implementation.`,
+    };
+  }
+}

--- a/src/tools/sandbox.ts
+++ b/src/tools/sandbox.ts
@@ -1,0 +1,273 @@
+/**
+ * 沙箱执行支持
+ * 使用 Bubblewrap (bwrap) 实现命令隔离
+ */
+
+import { spawn, spawnSync, SpawnSyncReturns } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+
+export interface SandboxOptions {
+  /** 工作目录 */
+  cwd?: string;
+  /** 环境变量 */
+  env?: Record<string, string>;
+  /** 超时时间（毫秒） */
+  timeout?: number;
+  /** 允许写入的路径 */
+  writablePaths?: string[];
+  /** 允许读取的路径 */
+  readOnlyPaths?: string[];
+  /** 是否允许网络访问 */
+  network?: boolean;
+  /** 是否禁用沙箱 */
+  disableSandbox?: boolean;
+}
+
+export interface SandboxResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  killed: boolean;
+  error?: string;
+}
+
+/**
+ * 检查 bubblewrap 是否可用
+ */
+export function isBubblewrapAvailable(): boolean {
+  try {
+    const result = spawnSync('which', ['bwrap'], { encoding: 'utf-8' });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 获取沙箱的默认配置
+ */
+function getDefaultSandboxConfig(cwd: string): string[] {
+  const home = os.homedir();
+  const tmpDir = os.tmpdir();
+
+  return [
+    // 基本的隔离设置
+    '--unshare-all',        // 取消共享所有命名空间
+    '--share-net',          // 但共享网络（可选）
+    '--die-with-parent',    // 父进程退出时终止
+
+    // 基础文件系统
+    '--ro-bind', '/usr', '/usr',
+    '--ro-bind', '/bin', '/bin',
+    '--ro-bind', '/lib', '/lib',
+    '--ro-bind', '/lib64', '/lib64',
+    '--symlink', '/usr/lib', '/lib',
+    '--symlink', '/usr/lib64', '/lib64',
+    '--symlink', '/usr/bin', '/bin',
+
+    // /etc 下的必要文件
+    '--ro-bind', '/etc/resolv.conf', '/etc/resolv.conf',
+    '--ro-bind', '/etc/hosts', '/etc/hosts',
+    '--ro-bind', '/etc/passwd', '/etc/passwd',
+    '--ro-bind', '/etc/group', '/etc/group',
+    '--ro-bind', '/etc/ssl', '/etc/ssl',
+    '--ro-bind', '/etc/ca-certificates', '/etc/ca-certificates',
+
+    // proc 和 dev
+    '--proc', '/proc',
+    '--dev', '/dev',
+
+    // 临时目录
+    '--tmpfs', '/tmp',
+    '--bind', tmpDir, tmpDir,
+
+    // 工作目录（可写）
+    '--bind', cwd, cwd,
+    '--chdir', cwd,
+
+    // 用户目录（只读）
+    '--ro-bind', home, home,
+
+    // Node.js 和 npm 相关
+    '--ro-bind', '/usr/local', '/usr/local',
+  ];
+}
+
+/**
+ * 使用沙箱执行命令
+ */
+export async function executeInSandbox(
+  command: string,
+  options: SandboxOptions = {}
+): Promise<SandboxResult> {
+  const {
+    cwd = process.cwd(),
+    env = {},
+    timeout = 120000,
+    writablePaths = [],
+    readOnlyPaths = [],
+    network = true,
+    disableSandbox = false,
+  } = options;
+
+  // 如果禁用沙箱或 bwrap 不可用，直接执行
+  if (disableSandbox || !isBubblewrapAvailable()) {
+    return executeDirectly(command, { cwd, env, timeout });
+  }
+
+  // 构建 bwrap 参数
+  const bwrapArgs = getDefaultSandboxConfig(cwd);
+
+  // 如果禁用网络
+  if (!network) {
+    const netIdx = bwrapArgs.indexOf('--share-net');
+    if (netIdx >= 0) {
+      bwrapArgs.splice(netIdx, 1);
+    }
+  }
+
+  // 添加额外的可写路径
+  for (const p of writablePaths) {
+    if (fs.existsSync(p)) {
+      bwrapArgs.push('--bind', p, p);
+    }
+  }
+
+  // 添加额外的只读路径
+  for (const p of readOnlyPaths) {
+    if (fs.existsSync(p)) {
+      bwrapArgs.push('--ro-bind', p, p);
+    }
+  }
+
+  // 添加命令
+  bwrapArgs.push('--', 'bash', '-c', command);
+
+  return new Promise((resolve) => {
+    let stdout = '';
+    let stderr = '';
+    let killed = false;
+
+    const proc = spawn('bwrap', bwrapArgs, {
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const timeoutId = setTimeout(() => {
+      killed = true;
+      proc.kill('SIGKILL');
+    }, timeout);
+
+    proc.stdout?.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr?.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    proc.on('close', (code) => {
+      clearTimeout(timeoutId);
+      resolve({
+        stdout,
+        stderr,
+        exitCode: code,
+        killed,
+      });
+    });
+
+    proc.on('error', (err) => {
+      clearTimeout(timeoutId);
+      resolve({
+        stdout,
+        stderr,
+        exitCode: null,
+        killed: false,
+        error: err.message,
+      });
+    });
+  });
+}
+
+/**
+ * 直接执行命令（无沙箱）
+ */
+async function executeDirectly(
+  command: string,
+  options: { cwd: string; env: Record<string, string>; timeout: number }
+): Promise<SandboxResult> {
+  const { cwd, env, timeout } = options;
+
+  return new Promise((resolve) => {
+    let stdout = '';
+    let stderr = '';
+    let killed = false;
+
+    const proc = spawn('bash', ['-c', command], {
+      cwd,
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const timeoutId = setTimeout(() => {
+      killed = true;
+      proc.kill('SIGKILL');
+    }, timeout);
+
+    proc.stdout?.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr?.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    proc.on('close', (code) => {
+      clearTimeout(timeoutId);
+      resolve({
+        stdout,
+        stderr,
+        exitCode: code,
+        killed,
+      });
+    });
+
+    proc.on('error', (err) => {
+      clearTimeout(timeoutId);
+      resolve({
+        stdout,
+        stderr,
+        exitCode: null,
+        killed: false,
+        error: err.message,
+      });
+    });
+  });
+}
+
+/**
+ * 沙箱状态信息
+ */
+export function getSandboxStatus(): {
+  available: boolean;
+  type: 'bubblewrap' | 'none';
+  version?: string;
+} {
+  if (isBubblewrapAvailable()) {
+    try {
+      const result = spawnSync('bwrap', ['--version'], { encoding: 'utf-8' });
+      const version = result.stdout?.trim() || result.stderr?.trim();
+      return {
+        available: true,
+        type: 'bubblewrap',
+        version,
+      };
+    } catch {
+      return { available: true, type: 'bubblewrap' };
+    }
+  }
+
+  return { available: false, type: 'none' };
+}


### PR DESCRIPTION
- Add NotebookEdit tool for Jupyter notebook cell editing
- Add EnterPlanMode/ExitPlanMode tools for planning workflow
- Add MCP protocol client with ListMcpResources/ReadMcpResource
- Add AskUserQuestion tool for user interaction
- Add Bubblewrap sandbox support for secure Bash execution
- Add Hooks system with PreToolUse/PostToolUse events
- Improve Bash tool with sandbox integration and hooks
- Update tools registry with 19 total tools
- Update README with comprehensive documentation

This brings the restored implementation to ~85% feature parity with the official @anthropic-ai/claude-code package.