### PR TITLE
Fix npm run dev error

### DIFF
--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -9,7 +9,7 @@ export { ModelStats, modelStats } from './stats.js';
 export { ThinkingManager, thinkingManager } from './thinking.js';
 export { QuotaManager, quotaManager } from './quota.js';
 export { SubagentModelConfig, subagentModelConfig, AGENT_TYPES, type ModelSelectionStrategy } from './subagent-config.js';
-export {
+export type {
   ModelInfo,
   ModelCapabilities,
   ModelPricing,

--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -4,9 +4,8 @@
  */
 
 // 代理支持
+export type { ProxyConfig, ProxyAgentOptions } from './proxy.js';
 export {
-  ProxyConfig,
-  ProxyAgentOptions,
   getProxyFromEnv,
   parseProxyUrl,
   shouldBypassProxy,
@@ -15,8 +14,8 @@ export {
 } from './proxy.js';
 
 // 超时和取消
+export type { TimeoutConfig } from './timeout.js';
 export {
-  TimeoutConfig,
   DEFAULT_TIMEOUTS,
   createTimeoutSignal,
   combineSignals,
@@ -29,8 +28,8 @@ export {
 } from './timeout.js';
 
 // 重试策略
+export type { RetryConfig } from './retry.js';
 export {
-  RetryConfig,
   DEFAULT_RETRY_CONFIG,
   calculateRetryDelay,
   isRetryableError,

--- a/src/prompt/index.ts
+++ b/src/prompt/index.ts
@@ -8,7 +8,7 @@ export { AttachmentManager, attachmentManager } from './attachments.js';
 export { PromptTemplates, CORE_IDENTITY, TOOL_GUIDELINES, PERMISSION_MODES } from './templates.js';
 export { PromptCache, promptCache } from './cache.js';
 export { PromptPreview, promptPreview } from './preview.js';
-export {
+export type {
   PromptContext,
   Attachment,
   AttachmentType,


### PR DESCRIPTION
Fix ESM module resolution errors when running npm run dev. TypeScript interfaces must use 'export type' syntax when re-exporting from index files to work correctly with tsx.