### PR TITLE
Implement WebUI for current project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "cli-highlight": "^2.1.11",
         "commander": "^12.0.0",
         "eventsource": "^4.1.0",
+        "express": "^5.2.1",
         "file-type": "^18.0.0",
         "glob": "^10.3.0",
         "http-proxy-agent": "^7.0.2",
@@ -41,7 +42,8 @@
       },
       "bin": {
         "claude": "dist/cli.js",
-        "claude-code-open": "dist/cli.js"
+        "claude-code-open": "dist/cli.js",
+        "claude-web": "dist/web-cli.js"
       },
       "devDependencies": {
         "@anthropic-ai/claude-code": "^2.0.76",
@@ -53,7 +55,6 @@
         "@types/uuid": "^9.0.0",
         "@types/ws": "^8.18.1",
         "@vitest/ui": "^4.0.16",
-        "express": "^5.2.1",
         "tsx": "^4.7.0",
         "typescript": "^5.3.0",
         "vitest": "^4.0.16"
@@ -1893,7 +1894,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -1907,7 +1907,6 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1917,7 +1916,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -2053,7 +2051,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
       "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -2078,7 +2075,6 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
       "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -2149,7 +2145,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2172,7 +2167,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2552,7 +2546,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
       "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2566,7 +2559,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2585,7 +2577,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2595,7 +2586,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -2720,7 +2710,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2814,7 +2803,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
@@ -2827,7 +2815,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2987,7 +2974,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -3013,7 +2999,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3072,7 +3057,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -3116,7 +3100,6 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3126,7 +3109,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -3185,7 +3167,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -3266,7 +3247,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3276,7 +3256,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3501,7 +3480,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -3592,7 +3570,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ink": {
@@ -3662,7 +3639,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -3750,7 +3726,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-wsl": {
@@ -3864,7 +3839,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3874,7 +3848,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3987,7 +3960,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4038,7 +4010,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4062,7 +4033,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -4075,7 +4045,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -4175,7 +4144,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4225,7 +4193,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
       "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -4326,7 +4293,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -4346,7 +4312,6 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -4362,7 +4327,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4372,7 +4336,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -4388,7 +4351,6 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
       "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -4548,7 +4510,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -4624,7 +4585,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -4651,7 +4611,6 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4661,7 +4620,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -4678,7 +4636,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -4698,7 +4655,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/sharp": {
@@ -4765,7 +4721,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4785,7 +4740,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4802,7 +4756,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -4821,7 +4774,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -4982,7 +4934,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5207,7 +5158,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -5324,7 +5274,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
@@ -5339,7 +5288,6 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5349,7 +5297,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -5396,7 +5343,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5419,7 +5365,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5756,7 +5701,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "bin": {
     "claude": "./dist/cli.js",
-    "claude-code-open": "./dist/cli.js"
+    "claude-code-open": "./dist/cli.js",
+    "claude-web": "./dist/web-cli.js"
   },
   "engines": {
     "node": ">=18.0.0"
@@ -19,6 +20,9 @@
     "build": "tsc",
     "start": "node dist/cli.js",
     "dev": "tsx src/cli.ts",
+    "web": "tsx src/web-cli.ts",
+    "web:start": "node dist/web-cli.js",
+    "web:dev": "tsx watch src/web-cli.ts",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:integration": "vitest tests/integration",
@@ -73,7 +77,8 @@
     "uuid": "^9.0.0",
     "web-tree-sitter": "^0.26.3",
     "ws": "^8.18.3",
-    "zod": "^3.22.0"
+    "zod": "^3.22.0",
+    "express": "^5.2.1"
   },
   "devDependencies": {
     "@anthropic-ai/claude-code": "^2.0.76",
@@ -85,7 +90,6 @@
     "@types/uuid": "^9.0.0",
     "@types/ws": "^8.18.1",
     "@vitest/ui": "^4.0.16",
-    "express": "^5.2.1",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0",
     "vitest": "^4.0.16"

--- a/src/web-cli.ts
+++ b/src/web-cli.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * WebUI CLI 入口
+ * 启动 Web 服务器
+ */
+
+import { Command } from 'commander';
+import { startWebServer } from './web/index.js';
+
+const program = new Command();
+
+program
+  .name('claude-web')
+  .description('Claude Code WebUI 服务器')
+  .version('2.0.76')
+  .option('-p, --port <port>', '服务器端口', '3456')
+  .option('-H, --host <host>', '服务器主机', 'localhost')
+  .option('-m, --model <model>', '默认模型 (opus/sonnet/haiku)', 'sonnet')
+  .option('-d, --dir <directory>', '工作目录', process.cwd())
+  .action(async (options) => {
+    console.log(`
+╔═══════════════════════════════════════════════════════════╗
+║                                                           ║
+║   🤖 Claude Code WebUI                                    ║
+║                                                           ║
+║   一个基于 Web 的 Claude Code 界面                        ║
+║                                                           ║
+╚═══════════════════════════════════════════════════════════╝
+`);
+
+    try {
+      await startWebServer({
+        port: parseInt(options.port),
+        host: options.host,
+        model: options.model,
+        cwd: options.dir,
+      });
+    } catch (error) {
+      console.error('启动失败:', error);
+      process.exit(1);
+    }
+  });
+
+program.parse();

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -1,0 +1,7 @@
+/**
+ * WebUI 模块导出
+ */
+
+export * from './shared/types.js';
+export { startWebServer, type WebServerOptions } from './server/index.js';
+export { ConversationManager, type StreamCallbacks } from './server/conversation.js';

--- a/src/web/server/conversation.ts
+++ b/src/web/server/conversation.ts
@@ -1,0 +1,656 @@
+/**
+ * 对话管理器
+ * 封装核心对话逻辑，提供 WebUI 专用接口
+ */
+
+import { ClaudeClient } from '../../core/client.js';
+import { Session } from '../../core/session.js';
+import { toolRegistry } from '../../tools/index.js';
+import { systemPromptBuilder } from '../../prompt/index.js';
+import { modelConfig } from '../../models/index.js';
+import type { Message, ContentBlock, ToolUseBlock, TextBlock } from '../../types/index.js';
+import type { ChatMessage, ChatContent, ToolResultData } from '../shared/types.js';
+
+/**
+ * 流式回调接口
+ */
+export interface StreamCallbacks {
+  onThinkingStart?: () => void;
+  onThinkingDelta?: (text: string) => void;
+  onThinkingComplete?: () => void;
+  onTextDelta?: (text: string) => void;
+  onToolUseStart?: (toolUseId: string, toolName: string, input: unknown) => void;
+  onToolUseDelta?: (toolUseId: string, partialJson: string) => void;
+  onToolResult?: (toolUseId: string, success: boolean, output?: string, error?: string, data?: ToolResultData) => void;
+  onComplete?: (stopReason: string | null, usage?: { inputTokens: number; outputTokens: number }) => void;
+  onError?: (error: Error) => void;
+}
+
+/**
+ * 会话状态
+ */
+interface SessionState {
+  session: Session;
+  client: ClaudeClient;
+  messages: Message[];
+  model: string;
+  cancelled: boolean;
+  chatHistory: ChatMessage[];
+}
+
+/**
+ * 对话管理器
+ */
+export class ConversationManager {
+  private sessions = new Map<string, SessionState>();
+  private cwd: string;
+  private defaultModel: string;
+
+  constructor(cwd: string, defaultModel: string = 'sonnet') {
+    this.cwd = cwd;
+    this.defaultModel = defaultModel;
+  }
+
+  /**
+   * 初始化
+   */
+  async initialize(): Promise<void> {
+    // 确保工具已注册
+    console.log(`[ConversationManager] 已注册 ${toolRegistry.getAll().length} 个工具`);
+  }
+
+  /**
+   * 获取或创建会话
+   */
+  private async getOrCreateSession(sessionId: string, model?: string): Promise<SessionState> {
+    let state = this.sessions.get(sessionId);
+
+    if (!state) {
+      const session = new Session(this.cwd);
+      await session.initializeGitInfo();
+
+      const client = new ClaudeClient({
+        model: this.getModelId(model || this.defaultModel),
+      });
+
+      state = {
+        session,
+        client,
+        messages: [],
+        model: model || this.defaultModel,
+        cancelled: false,
+        chatHistory: [],
+      };
+
+      this.sessions.set(sessionId, state);
+    }
+
+    return state;
+  }
+
+  /**
+   * 获取完整模型 ID
+   */
+  private getModelId(shortName: string): string {
+    const modelMap: Record<string, string> = {
+      opus: 'claude-opus-4-20250514',
+      sonnet: 'claude-sonnet-4-20250514',
+      haiku: 'claude-3-5-haiku-20241022',
+    };
+    return modelMap[shortName] || shortName;
+  }
+
+  /**
+   * 设置模型
+   */
+  setModel(sessionId: string, model: string): void {
+    const state = this.sessions.get(sessionId);
+    if (state) {
+      state.model = model;
+      state.client = new ClaudeClient({
+        model: this.getModelId(model),
+      });
+    }
+  }
+
+  /**
+   * 获取历史记录
+   */
+  getHistory(sessionId: string): ChatMessage[] {
+    const state = this.sessions.get(sessionId);
+    return state?.chatHistory || [];
+  }
+
+  /**
+   * 清除历史
+   */
+  clearHistory(sessionId: string): void {
+    const state = this.sessions.get(sessionId);
+    if (state) {
+      state.messages = [];
+      state.chatHistory = [];
+    }
+  }
+
+  /**
+   * 取消当前操作
+   */
+  cancel(sessionId: string): void {
+    const state = this.sessions.get(sessionId);
+    if (state) {
+      state.cancelled = true;
+    }
+  }
+
+  /**
+   * 发送聊天消息
+   */
+  async chat(
+    sessionId: string,
+    content: string,
+    images: string[] | undefined,
+    model: string,
+    callbacks: StreamCallbacks
+  ): Promise<void> {
+    const state = await this.getOrCreateSession(sessionId, model);
+    state.cancelled = false;
+
+    try {
+      // 构建用户消息
+      const userMessage: Message = {
+        role: 'user',
+        content: content,
+      };
+
+      // 如果有图片，转换为多内容块格式
+      if (images && images.length > 0) {
+        const contentBlocks: any[] = [{ type: 'text', text: content }];
+        for (const imageData of images) {
+          // 假设是 base64 格式
+          contentBlocks.push({
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: 'image/png',
+              data: imageData,
+            },
+          });
+        }
+        userMessage.content = contentBlocks;
+      }
+
+      state.messages.push(userMessage);
+
+      // 添加到聊天历史
+      state.chatHistory.push({
+        id: `user-${Date.now()}`,
+        role: 'user',
+        timestamp: Date.now(),
+        content: [{ type: 'text', text: content }],
+      });
+
+      // 开始对话循环
+      await this.conversationLoop(state, callbacks);
+
+    } catch (error) {
+      callbacks.onError?.(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  /**
+   * 对话循环
+   */
+  private async conversationLoop(
+    state: SessionState,
+    callbacks: StreamCallbacks
+  ): Promise<void> {
+    let continueLoop = true;
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+
+    while (continueLoop && !state.cancelled) {
+      // 构建系统提示
+      const systemPrompt = await this.buildSystemPrompt(state);
+
+      // 获取工具定义（使用旧格式兼容 createMessageStream）
+      const tools = toolRegistry.getAll().map(tool => ({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.getInputSchema(),
+      }));
+
+      try {
+        // 调用 Claude API（使用 createMessageStream）
+        const stream = state.client.createMessageStream(
+          state.messages,
+          tools,
+          systemPrompt
+        );
+
+        // 处理流式响应
+        const assistantContent: ContentBlock[] = [];
+        let currentTextContent = '';
+        let currentToolUse: { id: string; name: string; inputJson: string } | null = null;
+        let stopReason: string | null = null;
+        let thinkingStarted = false;
+
+        for await (const event of stream) {
+          if (state.cancelled) break;
+
+          switch (event.type) {
+            case 'thinking':
+              if (!thinkingStarted) {
+                callbacks.onThinkingStart?.();
+                thinkingStarted = true;
+              }
+              if (event.thinking) {
+                callbacks.onThinkingDelta?.(event.thinking);
+              }
+              break;
+
+            case 'text':
+              if (thinkingStarted) {
+                callbacks.onThinkingComplete?.();
+                thinkingStarted = false;
+              }
+              if (event.text) {
+                currentTextContent += event.text;
+                callbacks.onTextDelta?.(event.text);
+              }
+              break;
+
+            case 'tool_use_start':
+              // 保存之前的文本内容
+              if (currentTextContent) {
+                assistantContent.push({ type: 'text', text: currentTextContent } as TextBlock);
+                currentTextContent = '';
+              }
+              // 开始新的工具调用
+              currentToolUse = {
+                id: event.id || '',
+                name: event.name || '',
+                inputJson: '',
+              };
+              callbacks.onToolUseStart?.(currentToolUse.id, currentToolUse.name, {});
+              break;
+
+            case 'tool_use_delta':
+              if (currentToolUse && event.input) {
+                currentToolUse.inputJson += event.input;
+                callbacks.onToolUseDelta?.(currentToolUse.id, event.input);
+              }
+              break;
+
+            case 'stop':
+              // 完成当前文本块
+              if (currentTextContent) {
+                assistantContent.push({ type: 'text', text: currentTextContent } as TextBlock);
+                currentTextContent = '';
+              }
+              // 完成当前工具调用
+              if (currentToolUse) {
+                let parsedInput = {};
+                try {
+                  parsedInput = JSON.parse(currentToolUse.inputJson || '{}');
+                } catch (e) {
+                  // 解析失败使用空对象
+                }
+                assistantContent.push({
+                  type: 'tool_use',
+                  id: currentToolUse.id,
+                  name: currentToolUse.name,
+                  input: parsedInput,
+                } as ToolUseBlock);
+                currentToolUse = null;
+              }
+              stopReason = event.stopReason || null;
+              break;
+
+            case 'usage':
+              if (event.usage) {
+                totalInputTokens = event.usage.inputTokens || 0;
+                totalOutputTokens = event.usage.outputTokens || 0;
+              }
+              break;
+
+            case 'error':
+              throw new Error(event.error || 'Unknown stream error');
+          }
+        }
+
+        // 保存助手响应
+        if (assistantContent.length > 0) {
+          state.messages.push({
+            role: 'assistant',
+            content: assistantContent,
+          });
+        }
+
+        // 处理工具调用
+        const toolUseBlocks = assistantContent.filter(
+          (block): block is ToolUseBlock => block.type === 'tool_use'
+        );
+
+        if (toolUseBlocks.length > 0 && stopReason === 'tool_use') {
+          // 执行工具并收集结果
+          const toolResults: any[] = [];
+
+          for (const toolUse of toolUseBlocks) {
+            if (state.cancelled) break;
+
+            const result = await this.executeTool(toolUse, state, callbacks);
+            toolResults.push({
+              type: 'tool_result',
+              tool_use_id: toolUse.id,
+              content: result.success ? result.output : `Error: ${result.error}`,
+              is_error: !result.success,
+            });
+          }
+
+          // 添加工具结果到消息
+          if (toolResults.length > 0) {
+            state.messages.push({
+              role: 'user',
+              content: toolResults,
+            });
+          }
+
+          // 继续循环
+          continueLoop = true;
+        } else {
+          // 对话结束
+          continueLoop = false;
+
+          // 添加到聊天历史
+          const chatContent: ChatContent[] = assistantContent.map(block => {
+            if (block.type === 'text') {
+              return { type: 'text', text: (block as TextBlock).text };
+            } else if (block.type === 'tool_use') {
+              const toolBlock = block as ToolUseBlock;
+              return {
+                type: 'tool_use',
+                id: toolBlock.id,
+                name: toolBlock.name,
+                input: toolBlock.input,
+                status: 'completed' as const,
+              };
+            }
+            return { type: 'text', text: '' };
+          });
+
+          state.chatHistory.push({
+            id: `assistant-${Date.now()}`,
+            role: 'assistant',
+            timestamp: Date.now(),
+            content: chatContent,
+            model: state.model,
+            usage: {
+              inputTokens: totalInputTokens,
+              outputTokens: totalOutputTokens,
+            },
+          });
+
+          callbacks.onComplete?.(stopReason, {
+            inputTokens: totalInputTokens,
+            outputTokens: totalOutputTokens,
+          });
+        }
+
+      } catch (error) {
+        console.error('[ConversationManager] API 错误:', error);
+        callbacks.onError?.(error instanceof Error ? error : new Error(String(error)));
+        continueLoop = false;
+      }
+    }
+  }
+
+  /**
+   * 执行工具
+   */
+  private async executeTool(
+    toolUse: ToolUseBlock,
+    state: SessionState,
+    callbacks: StreamCallbacks
+  ): Promise<{ success: boolean; output?: string; error?: string; data?: ToolResultData }> {
+    const tool = toolRegistry.get(toolUse.name);
+
+    if (!tool) {
+      const error = `未知工具: ${toolUse.name}`;
+      callbacks.onToolResult?.(toolUse.id, false, undefined, error);
+      return { success: false, error };
+    }
+
+    try {
+      console.log(`[Tool] 执行 ${toolUse.name}:`, JSON.stringify(toolUse.input).slice(0, 200));
+
+      // 执行工具
+      const result = await tool.execute(toolUse.input);
+
+      // 构建结构化数据
+      const data = this.buildToolResultData(toolUse.name, toolUse.input, result);
+
+      // 格式化输出
+      let output: string;
+      if (typeof result === 'string') {
+        output = result;
+      } else if (result && typeof result === 'object') {
+        if ('output' in result) {
+          output = result.output as string;
+        } else if ('content' in result) {
+          output = result.content as string;
+        } else {
+          output = JSON.stringify(result, null, 2);
+        }
+      } else {
+        output = String(result);
+      }
+
+      // 截断过长输出
+      const maxOutputLength = 50000;
+      if (output.length > maxOutputLength) {
+        output = output.slice(0, maxOutputLength) + '\n... (输出已截断)';
+      }
+
+      callbacks.onToolResult?.(toolUse.id, true, output, undefined, data);
+      return { success: true, output, data };
+
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error(`[Tool] ${toolUse.name} 执行失败:`, errorMessage);
+      callbacks.onToolResult?.(toolUse.id, false, undefined, errorMessage);
+      return { success: false, error: errorMessage };
+    }
+  }
+
+  /**
+   * 构建工具结果的结构化数据
+   */
+  private buildToolResultData(
+    toolName: string,
+    input: unknown,
+    result: unknown
+  ): ToolResultData | undefined {
+    const inputObj = input as Record<string, unknown>;
+
+    switch (toolName) {
+      case 'Bash':
+        return {
+          tool: 'Bash',
+          command: (inputObj.command as string) || '',
+          exitCode: (result as any)?.exitCode,
+          stdout: (result as any)?.stdout || (result as any)?.output,
+          stderr: (result as any)?.stderr,
+          duration: (result as any)?.duration,
+        };
+
+      case 'Read':
+        const content = typeof result === 'string' ? result : (result as any)?.content || '';
+        return {
+          tool: 'Read',
+          filePath: (inputObj.file_path as string) || '',
+          content: content.slice(0, 10000), // 限制长度
+          lineCount: content.split('\n').length,
+          language: this.detectLanguage((inputObj.file_path as string) || ''),
+        };
+
+      case 'Write':
+        return {
+          tool: 'Write',
+          filePath: (inputObj.file_path as string) || '',
+          bytesWritten: (inputObj.content as string)?.length || 0,
+        };
+
+      case 'Edit':
+        return {
+          tool: 'Edit',
+          filePath: (inputObj.file_path as string) || '',
+          diff: [], // 需要解析 diff
+          linesAdded: 0,
+          linesRemoved: 0,
+        };
+
+      case 'Glob':
+        const files = Array.isArray(result) ? result :
+          typeof result === 'string' ? result.split('\n').filter(Boolean) :
+          (result as any)?.files || [];
+        return {
+          tool: 'Glob',
+          pattern: (inputObj.pattern as string) || '',
+          files: files.slice(0, 100),
+          totalCount: files.length,
+        };
+
+      case 'Grep':
+        return {
+          tool: 'Grep',
+          pattern: (inputObj.pattern as string) || '',
+          matches: [],
+          totalCount: 0,
+        };
+
+      case 'WebFetch':
+        return {
+          tool: 'WebFetch',
+          url: (inputObj.url as string) || '',
+          title: (result as any)?.title,
+          contentPreview: typeof result === 'string' ? result.slice(0, 500) : undefined,
+        };
+
+      case 'WebSearch':
+        return {
+          tool: 'WebSearch',
+          query: (inputObj.query as string) || '',
+          results: (result as any)?.results || [],
+        };
+
+      case 'TodoWrite':
+        return {
+          tool: 'TodoWrite',
+          todos: (inputObj.todos as any[]) || [],
+        };
+
+      case 'Task':
+        return {
+          tool: 'Task',
+          agentType: (inputObj.subagent_type as string) || 'general-purpose',
+          description: (inputObj.description as string) || '',
+          status: 'completed',
+          output: typeof result === 'string' ? result : JSON.stringify(result),
+        };
+
+      default:
+        return undefined;
+    }
+  }
+
+  /**
+   * 检测文件语言
+   */
+  private detectLanguage(filePath: string): string {
+    const ext = filePath.split('.').pop()?.toLowerCase();
+    const langMap: Record<string, string> = {
+      ts: 'typescript',
+      tsx: 'typescript',
+      js: 'javascript',
+      jsx: 'javascript',
+      py: 'python',
+      rb: 'ruby',
+      go: 'go',
+      rs: 'rust',
+      java: 'java',
+      cpp: 'cpp',
+      c: 'c',
+      h: 'c',
+      hpp: 'cpp',
+      cs: 'csharp',
+      php: 'php',
+      swift: 'swift',
+      kt: 'kotlin',
+      scala: 'scala',
+      sh: 'bash',
+      bash: 'bash',
+      zsh: 'bash',
+      json: 'json',
+      yaml: 'yaml',
+      yml: 'yaml',
+      xml: 'xml',
+      html: 'html',
+      css: 'css',
+      scss: 'scss',
+      less: 'less',
+      sql: 'sql',
+      md: 'markdown',
+      txt: 'text',
+    };
+    return langMap[ext || ''] || 'text';
+  }
+
+  /**
+   * 构建系统提示
+   */
+  private async buildSystemPrompt(state: SessionState): Promise<string> {
+    const gitInfo = state.session.getGitInfo();
+
+    const context = {
+      cwd: state.session.cwd,
+      platform: process.platform,
+      date: new Date().toISOString().split('T')[0],
+      gitBranch: gitInfo?.branchName,
+      gitStatus: state.session.getFormattedGitStatus(),
+    };
+
+    // 使用简化的系统提示
+    let prompt = `You are Claude, an AI assistant created by Anthropic to help with programming tasks.
+
+## Environment
+- Working Directory: ${context.cwd}
+- Platform: ${context.platform}
+- Date: ${context.date}`;
+
+    if (context.gitBranch) {
+      prompt += `\n- Git Branch: ${context.gitBranch}`;
+    }
+
+    prompt += `
+
+## Guidelines
+1. Use the available tools to help users with their tasks
+2. Read files before editing them
+3. Be concise and helpful
+4. When using Bash, quote paths with spaces
+5. Use appropriate tools for each task:
+   - Read/Write/Edit for file operations
+   - Glob/Grep for searching
+   - Bash for system commands
+   - Task for complex multi-step operations
+   - TodoWrite for tracking progress
+
+## Available Tools
+You have access to the following tools:
+${toolRegistry.getAll().map(t => `- ${t.name}: ${t.description.slice(0, 100)}...`).join('\n')}
+
+Respond in Chinese when the user writes in Chinese.`;
+
+    return prompt;
+  }
+}

--- a/src/web/server/index.ts
+++ b/src/web/server/index.ts
@@ -1,0 +1,1179 @@
+/**
+ * WebUI 服务器入口
+ * Express + WebSocket 服务器
+ */
+
+import express from 'express';
+import { createServer } from 'http';
+import { WebSocketServer } from 'ws';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { ConversationManager } from './conversation.js';
+import { setupWebSocket } from './websocket.js';
+import { setupApiRoutes } from './routes/api.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export interface WebServerOptions {
+  port?: number;
+  host?: string;
+  cwd?: string;
+  model?: string;
+}
+
+export async function startWebServer(options: WebServerOptions = {}): Promise<void> {
+  const {
+    port = parseInt(process.env.CLAUDE_WEB_PORT || '3456'),
+    host = process.env.CLAUDE_WEB_HOST || 'localhost',
+    cwd = process.cwd(),
+    model = process.env.CLAUDE_MODEL || 'sonnet',
+  } = options;
+
+  // 创建 Express 应用
+  const app = express();
+  const server = createServer(app);
+
+  // 创建 WebSocket 服务器
+  const wss = new WebSocketServer({ server, path: '/ws' });
+
+  // 创建对话管理器
+  const conversationManager = new ConversationManager(cwd, model);
+  await conversationManager.initialize();
+
+  // 中间件
+  app.use(express.json({ limit: '50mb' }));
+  app.use(express.urlencoded({ extended: true }));
+
+  // CORS 配置（开发模式）
+  app.use((req, res, next) => {
+    res.header('Access-Control-Allow-Origin', '*');
+    res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+    res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    if (req.method === 'OPTIONS') {
+      return res.sendStatus(200);
+    }
+    next();
+  });
+
+  // API 路由
+  setupApiRoutes(app, conversationManager);
+
+  // 静态文件服务（生产模式）
+  const clientDistPath = path.join(__dirname, '../client/dist');
+  app.use(express.static(clientDistPath));
+
+  // 内联 HTML（所有请求返回 SPA）
+  // 使用 use 中间件作为 catch-all（Express 5 兼容）
+  app.use((req, res, next) => {
+    // 跳过 API 路由和静态资源
+    if (req.path.startsWith('/api/') || req.path.startsWith('/ws')) {
+      return next();
+    }
+    res.send(getInlineHTML(port));
+  });
+
+  // 设置 WebSocket 处理
+  setupWebSocket(wss, conversationManager);
+
+  // 启动服务器
+  server.listen(port, host, () => {
+    console.log(`\n🌐 Claude Code WebUI 已启动`);
+    console.log(`   地址: http://${host}:${port}`);
+    console.log(`   WebSocket: ws://${host}:${port}/ws`);
+    console.log(`   工作目录: ${cwd}`);
+    console.log(`   模型: ${model}\n`);
+  });
+
+  // 优雅关闭
+  process.on('SIGINT', () => {
+    console.log('\n正在关闭服务器...');
+    wss.close();
+    server.close(() => {
+      console.log('服务器已关闭');
+      process.exit(0);
+    });
+  });
+}
+
+/**
+ * 获取内联 HTML
+ * 包含完整的前端应用
+ */
+function getInlineHTML(port: number): string {
+  return `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Claude Code WebUI</title>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+  <style>
+    ${getInlineCSS()}
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" data-type="module">
+    ${getInlineReactApp(port)}
+  </script>
+</body>
+</html>`;
+}
+
+/**
+ * 获取内联 CSS 样式
+ */
+function getInlineCSS(): string {
+  return `
+    :root {
+      --bg-primary: #1a1b26;
+      --bg-secondary: #24283b;
+      --bg-tertiary: #414868;
+      --text-primary: #c0caf5;
+      --text-secondary: #a9b1d6;
+      --text-muted: #565f89;
+      --accent-primary: #7aa2f7;
+      --accent-success: #9ece6a;
+      --accent-warning: #e0af68;
+      --accent-error: #f7768e;
+      --border-color: #414868;
+      --code-bg: #1f2335;
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      background: var(--bg-primary);
+      color: var(--text-primary);
+      min-height: 100vh;
+    }
+
+    #root {
+      display: flex;
+      height: 100vh;
+    }
+
+    /* 侧边栏 */
+    .sidebar {
+      width: 260px;
+      background: var(--bg-secondary);
+      border-right: 1px solid var(--border-color);
+      display: flex;
+      flex-direction: column;
+    }
+
+    .sidebar-header {
+      padding: 16px;
+      border-bottom: 1px solid var(--border-color);
+    }
+
+    .sidebar-header h1 {
+      font-size: 18px;
+      color: var(--accent-primary);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .new-chat-btn {
+      width: 100%;
+      padding: 10px;
+      margin-top: 12px;
+      background: var(--accent-primary);
+      color: var(--bg-primary);
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+      font-weight: 500;
+      transition: opacity 0.2s;
+    }
+
+    .new-chat-btn:hover {
+      opacity: 0.9;
+    }
+
+    .session-list {
+      flex: 1;
+      overflow-y: auto;
+      padding: 8px;
+    }
+
+    .session-item {
+      padding: 10px 12px;
+      border-radius: 6px;
+      cursor: pointer;
+      margin-bottom: 4px;
+      transition: background 0.2s;
+    }
+
+    .session-item:hover {
+      background: var(--bg-tertiary);
+    }
+
+    .session-item.active {
+      background: var(--bg-tertiary);
+    }
+
+    .sidebar-footer {
+      padding: 12px;
+      border-top: 1px solid var(--border-color);
+      font-size: 12px;
+      color: var(--text-muted);
+    }
+
+    /* 主聊天区域 */
+    .main-content {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+    }
+
+    .chat-header {
+      padding: 12px 20px;
+      background: var(--bg-secondary);
+      border-bottom: 1px solid var(--border-color);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .model-selector {
+      padding: 6px 12px;
+      background: var(--bg-tertiary);
+      border: 1px solid var(--border-color);
+      border-radius: 6px;
+      color: var(--text-primary);
+      cursor: pointer;
+    }
+
+    .chat-container {
+      flex: 1;
+      overflow-y: auto;
+      padding: 20px;
+    }
+
+    /* 消息样式 */
+    .message {
+      max-width: 900px;
+      margin: 0 auto 20px;
+      padding: 16px 20px;
+      border-radius: 12px;
+    }
+
+    .message.user {
+      background: var(--bg-tertiary);
+      margin-left: 60px;
+    }
+
+    .message.assistant {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border-color);
+    }
+
+    .message-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 8px;
+      font-size: 13px;
+      color: var(--text-muted);
+    }
+
+    .message-role {
+      font-weight: 600;
+      color: var(--text-secondary);
+    }
+
+    .message-content {
+      line-height: 1.6;
+    }
+
+    .message-content p {
+      margin-bottom: 12px;
+    }
+
+    .message-content p:last-child {
+      margin-bottom: 0;
+    }
+
+    .message-content pre {
+      background: var(--code-bg);
+      border-radius: 8px;
+      padding: 12px;
+      overflow-x: auto;
+      margin: 12px 0;
+    }
+
+    .message-content code {
+      font-family: 'Fira Code', 'JetBrains Mono', Consolas, monospace;
+      font-size: 13px;
+    }
+
+    .message-content :not(pre) > code {
+      background: var(--code-bg);
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+
+    /* 工具调用样式 */
+    .tool-call {
+      margin: 12px 0;
+      border: 1px solid var(--border-color);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+
+    .tool-call-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 14px;
+      background: var(--bg-tertiary);
+      cursor: pointer;
+      user-select: none;
+    }
+
+    .tool-call-header:hover {
+      background: #4a5178;
+    }
+
+    .tool-icon {
+      font-size: 16px;
+    }
+
+    .tool-name {
+      font-weight: 600;
+      color: var(--accent-primary);
+    }
+
+    .tool-status {
+      margin-left: auto;
+      font-size: 12px;
+      padding: 2px 8px;
+      border-radius: 10px;
+    }
+
+    .tool-status.running {
+      background: var(--accent-warning);
+      color: var(--bg-primary);
+    }
+
+    .tool-status.completed {
+      background: var(--accent-success);
+      color: var(--bg-primary);
+    }
+
+    .tool-status.error {
+      background: var(--accent-error);
+      color: var(--bg-primary);
+    }
+
+    .tool-call-body {
+      padding: 12px 14px;
+      background: var(--bg-primary);
+      font-size: 13px;
+    }
+
+    .tool-input, .tool-output {
+      margin-bottom: 12px;
+    }
+
+    .tool-input:last-child, .tool-output:last-child {
+      margin-bottom: 0;
+    }
+
+    .tool-label {
+      font-size: 11px;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      margin-bottom: 6px;
+    }
+
+    .tool-input pre, .tool-output pre {
+      margin: 0;
+      padding: 10px;
+      background: var(--code-bg);
+      border-radius: 6px;
+      overflow-x: auto;
+      font-size: 12px;
+    }
+
+    /* Diff 样式 */
+    .diff-view {
+      font-family: 'Fira Code', monospace;
+      font-size: 12px;
+      line-height: 1.5;
+    }
+
+    .diff-line {
+      padding: 2px 10px;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+
+    .diff-line.add {
+      background: rgba(158, 206, 106, 0.15);
+      color: var(--accent-success);
+    }
+
+    .diff-line.remove {
+      background: rgba(247, 118, 142, 0.15);
+      color: var(--accent-error);
+    }
+
+    .diff-line.context {
+      color: var(--text-muted);
+    }
+
+    .diff-line-number {
+      display: inline-block;
+      width: 40px;
+      color: var(--text-muted);
+      text-align: right;
+      margin-right: 10px;
+      user-select: none;
+    }
+
+    /* 文件路径样式 */
+    .file-path {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      background: var(--bg-tertiary);
+      border-radius: 4px;
+      font-family: monospace;
+      font-size: 12px;
+      color: var(--accent-primary);
+    }
+
+    /* Todo 列表样式 */
+    .todo-list {
+      list-style: none;
+    }
+
+    .todo-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 0;
+      border-bottom: 1px solid var(--border-color);
+    }
+
+    .todo-item:last-child {
+      border-bottom: none;
+    }
+
+    .todo-status-icon {
+      font-size: 14px;
+    }
+
+    .todo-content {
+      flex: 1;
+    }
+
+    .todo-item.completed .todo-content {
+      text-decoration: line-through;
+      color: var(--text-muted);
+    }
+
+    /* 输入区域 */
+    .input-area {
+      padding: 16px 20px;
+      background: var(--bg-secondary);
+      border-top: 1px solid var(--border-color);
+    }
+
+    .input-container {
+      max-width: 900px;
+      margin: 0 auto;
+      display: flex;
+      gap: 12px;
+    }
+
+    .input-wrapper {
+      flex: 1;
+      position: relative;
+    }
+
+    .chat-input {
+      width: 100%;
+      padding: 12px 16px;
+      background: var(--bg-primary);
+      border: 1px solid var(--border-color);
+      border-radius: 8px;
+      color: var(--text-primary);
+      font-size: 14px;
+      resize: none;
+      min-height: 48px;
+      max-height: 200px;
+      line-height: 1.5;
+    }
+
+    .chat-input:focus {
+      outline: none;
+      border-color: var(--accent-primary);
+    }
+
+    .chat-input::placeholder {
+      color: var(--text-muted);
+    }
+
+    .send-btn {
+      padding: 12px 20px;
+      background: var(--accent-primary);
+      color: var(--bg-primary);
+      border: none;
+      border-radius: 8px;
+      cursor: pointer;
+      font-weight: 500;
+      transition: opacity 0.2s;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .send-btn:hover:not(:disabled) {
+      opacity: 0.9;
+    }
+
+    .send-btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    /* 状态指示器 */
+    .status-indicator {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 16px;
+      font-size: 13px;
+      color: var(--text-muted);
+    }
+
+    .status-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--accent-success);
+    }
+
+    .status-dot.thinking {
+      background: var(--accent-warning);
+      animation: pulse 1s infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.5; }
+    }
+
+    /* 思考块样式 */
+    .thinking-block {
+      margin: 12px 0;
+      padding: 12px;
+      background: rgba(122, 162, 247, 0.1);
+      border-left: 3px solid var(--accent-primary);
+      border-radius: 0 8px 8px 0;
+      font-size: 13px;
+      color: var(--text-secondary);
+    }
+
+    .thinking-header {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 8px;
+      font-weight: 500;
+      color: var(--accent-primary);
+    }
+
+    /* 搜索结果样式 */
+    .search-results {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .search-result-item {
+      padding: 12px;
+      background: var(--bg-tertiary);
+      border-radius: 8px;
+    }
+
+    .search-result-title {
+      color: var(--accent-primary);
+      font-weight: 500;
+      margin-bottom: 4px;
+    }
+
+    .search-result-url {
+      font-size: 12px;
+      color: var(--text-muted);
+      margin-bottom: 6px;
+    }
+
+    .search-result-snippet {
+      font-size: 13px;
+      color: var(--text-secondary);
+    }
+
+    /* 滚动条样式 */
+    ::-webkit-scrollbar {
+      width: 8px;
+      height: 8px;
+    }
+
+    ::-webkit-scrollbar-track {
+      background: var(--bg-primary);
+    }
+
+    ::-webkit-scrollbar-thumb {
+      background: var(--bg-tertiary);
+      border-radius: 4px;
+    }
+
+    ::-webkit-scrollbar-thumb:hover {
+      background: var(--text-muted);
+    }
+
+    /* 加载动画 */
+    .loading-dots {
+      display: inline-flex;
+      gap: 4px;
+    }
+
+    .loading-dots span {
+      width: 6px;
+      height: 6px;
+      background: var(--accent-primary);
+      border-radius: 50%;
+      animation: loading 1.4s infinite both;
+    }
+
+    .loading-dots span:nth-child(2) {
+      animation-delay: 0.2s;
+    }
+
+    .loading-dots span:nth-child(3) {
+      animation-delay: 0.4s;
+    }
+
+    @keyframes loading {
+      0%, 80%, 100% {
+        transform: scale(0);
+        opacity: 0.5;
+      }
+      40% {
+        transform: scale(1);
+        opacity: 1;
+      }
+    }
+
+    /* 欢迎屏幕 */
+    .welcome-screen {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      text-align: center;
+      padding: 40px;
+    }
+
+    .welcome-icon {
+      font-size: 64px;
+      margin-bottom: 24px;
+    }
+
+    .welcome-title {
+      font-size: 28px;
+      font-weight: 600;
+      margin-bottom: 12px;
+      color: var(--text-primary);
+    }
+
+    .welcome-subtitle {
+      font-size: 16px;
+      color: var(--text-muted);
+      max-width: 500px;
+      line-height: 1.6;
+    }
+
+    /* 响应式 */
+    @media (max-width: 768px) {
+      .sidebar {
+        display: none;
+      }
+
+      .message.user {
+        margin-left: 20px;
+      }
+    }
+  `;
+}
+
+/**
+ * 获取内联 React 应用代码
+ */
+function getInlineReactApp(port: number): string {
+  return `
+    const { useState, useEffect, useRef, useCallback } = React;
+
+    // 工具名称映射
+    const TOOL_DISPLAY_NAMES = {
+      Bash: '终端命令',
+      BashOutput: '终端输出',
+      KillShell: '终止进程',
+      Read: '读取文件',
+      Write: '写入文件',
+      Edit: '编辑文件',
+      MultiEdit: '批量编辑',
+      Glob: '文件搜索',
+      Grep: '内容搜索',
+      WebFetch: '网页获取',
+      WebSearch: '网页搜索',
+      TodoWrite: '任务管理',
+      Task: '子任务',
+      NotebookEdit: '笔记本编辑',
+      AskUserQuestion: '询问用户',
+    };
+
+    // 工具图标映射
+    const TOOL_ICONS = {
+      Bash: '💻',
+      Read: '📖',
+      Write: '✏️',
+      Edit: '🔧',
+      MultiEdit: '📝',
+      Glob: '🔍',
+      Grep: '🔎',
+      WebFetch: '🌐',
+      WebSearch: '🔍',
+      TodoWrite: '✅',
+      Task: '🤖',
+      NotebookEdit: '📓',
+      AskUserQuestion: '❓',
+    };
+
+    // WebSocket Hook
+    function useWebSocket(url) {
+      const [connected, setConnected] = useState(false);
+      const [sessionId, setSessionId] = useState(null);
+      const [model, setModel] = useState('sonnet');
+      const wsRef = useRef(null);
+      const messageHandlersRef = useRef([]);
+
+      useEffect(() => {
+        const ws = new WebSocket(url);
+        wsRef.current = ws;
+
+        ws.onopen = () => {
+          console.log('WebSocket connected');
+          setConnected(true);
+        };
+
+        ws.onmessage = (event) => {
+          try {
+            const message = JSON.parse(event.data);
+            messageHandlersRef.current.forEach(handler => handler(message));
+
+            if (message.type === 'connected') {
+              setSessionId(message.payload.sessionId);
+              setModel(message.payload.model);
+            }
+          } catch (e) {
+            console.error('Failed to parse message:', e);
+          }
+        };
+
+        ws.onclose = () => {
+          console.log('WebSocket disconnected');
+          setConnected(false);
+        };
+
+        ws.onerror = (error) => {
+          console.error('WebSocket error:', error);
+        };
+
+        return () => {
+          ws.close();
+        };
+      }, [url]);
+
+      const send = useCallback((message) => {
+        if (wsRef.current?.readyState === WebSocket.OPEN) {
+          wsRef.current.send(JSON.stringify(message));
+        }
+      }, []);
+
+      const addMessageHandler = useCallback((handler) => {
+        messageHandlersRef.current.push(handler);
+        return () => {
+          messageHandlersRef.current = messageHandlersRef.current.filter(h => h !== handler);
+        };
+      }, []);
+
+      return { connected, sessionId, model, send, addMessageHandler };
+    }
+
+    // Markdown 渲染组件
+    function MarkdownContent({ content }) {
+      const ref = useRef(null);
+
+      useEffect(() => {
+        if (ref.current && content) {
+          ref.current.innerHTML = marked.parse(content);
+          ref.current.querySelectorAll('pre code').forEach((block) => {
+            hljs.highlightElement(block);
+          });
+        }
+      }, [content]);
+
+      return React.createElement('div', { ref, className: 'message-content' });
+    }
+
+    // 工具调用组件
+    function ToolCall({ toolUse }) {
+      const [expanded, setExpanded] = useState(true);
+      const { name, input, status, result } = toolUse;
+
+      const icon = TOOL_ICONS[name] || '🔧';
+      const displayName = TOOL_DISPLAY_NAMES[name] || name;
+
+      return React.createElement('div', { className: 'tool-call' },
+        React.createElement('div', {
+          className: 'tool-call-header',
+          onClick: () => setExpanded(!expanded)
+        },
+          React.createElement('span', { className: 'tool-icon' }, icon),
+          React.createElement('span', { className: 'tool-name' }, displayName),
+          React.createElement('span', { className: \`tool-status \${status}\` },
+            status === 'running' ? '执行中...' :
+            status === 'completed' ? '完成' :
+            status === 'error' ? '错误' : '等待中'
+          ),
+          React.createElement('span', null, expanded ? '▼' : '▶')
+        ),
+        expanded && React.createElement('div', { className: 'tool-call-body' },
+          React.createElement('div', { className: 'tool-input' },
+            React.createElement('div', { className: 'tool-label' }, '输入参数'),
+            React.createElement('pre', null,
+              React.createElement('code', null, JSON.stringify(input, null, 2))
+            )
+          ),
+          result && React.createElement('div', { className: 'tool-output' },
+            React.createElement('div', { className: 'tool-label' }, result.success ? '输出结果' : '错误信息'),
+            React.createElement('pre', null,
+              React.createElement('code', null, result.output || result.error || '(无输出)')
+            )
+          )
+        )
+      );
+    }
+
+    // 消息组件
+    function Message({ message }) {
+      const { role, content } = message;
+
+      const renderContent = (item, index) => {
+        if (item.type === 'text') {
+          return React.createElement(MarkdownContent, { key: index, content: item.text });
+        }
+        if (item.type === 'tool_use') {
+          return React.createElement(ToolCall, { key: index, toolUse: item });
+        }
+        if (item.type === 'thinking') {
+          return React.createElement('div', { key: index, className: 'thinking-block' },
+            React.createElement('div', { className: 'thinking-header' }, '💭 思考中'),
+            React.createElement('div', null, item.text)
+          );
+        }
+        return null;
+      };
+
+      return React.createElement('div', { className: \`message \${role}\` },
+        React.createElement('div', { className: 'message-header' },
+          React.createElement('span', { className: 'message-role' },
+            role === 'user' ? '你' : 'Claude'
+          ),
+          message.model && React.createElement('span', null, \`(\${message.model})\`)
+        ),
+        Array.isArray(content)
+          ? content.map(renderContent)
+          : React.createElement(MarkdownContent, { content })
+      );
+    }
+
+    // 欢迎屏幕组件
+    function WelcomeScreen() {
+      return React.createElement('div', { className: 'welcome-screen' },
+        React.createElement('div', { className: 'welcome-icon' }, '🤖'),
+        React.createElement('h2', { className: 'welcome-title' }, 'Claude Code WebUI'),
+        React.createElement('p', { className: 'welcome-subtitle' },
+          '欢迎使用 Claude Code 的 Web 界面。在下方输入框中输入你的问题或指令，我会帮助你完成编程任务。'
+        )
+      );
+    }
+
+    // 主应用组件
+    function App() {
+      const [messages, setMessages] = useState([]);
+      const [input, setInput] = useState('');
+      const [status, setStatus] = useState('idle');
+      const chatContainerRef = useRef(null);
+      const inputRef = useRef(null);
+
+      const { connected, sessionId, model, send, addMessageHandler } = useWebSocket(\`ws://localhost:${port}/ws\`);
+
+      // 当前正在构建的消息
+      const currentMessageRef = useRef(null);
+
+      useEffect(() => {
+        const unsubscribe = addMessageHandler((msg) => {
+          switch (msg.type) {
+            case 'message_start':
+              currentMessageRef.current = {
+                id: msg.payload.messageId,
+                role: 'assistant',
+                timestamp: Date.now(),
+                content: [],
+                model
+              };
+              setStatus('streaming');
+              break;
+
+            case 'text_delta':
+              if (currentMessageRef.current) {
+                const lastContent = currentMessageRef.current.content[currentMessageRef.current.content.length - 1];
+                if (lastContent?.type === 'text') {
+                  lastContent.text += msg.payload.text;
+                } else {
+                  currentMessageRef.current.content.push({ type: 'text', text: msg.payload.text });
+                }
+                setMessages(prev => {
+                  const filtered = prev.filter(m => m.id !== currentMessageRef.current.id);
+                  return [...filtered, { ...currentMessageRef.current }];
+                });
+              }
+              break;
+
+            case 'thinking_start':
+              if (currentMessageRef.current) {
+                currentMessageRef.current.content.push({ type: 'thinking', text: '' });
+                setStatus('thinking');
+              }
+              break;
+
+            case 'thinking_delta':
+              if (currentMessageRef.current) {
+                const thinkingContent = currentMessageRef.current.content.find(c => c.type === 'thinking');
+                if (thinkingContent) {
+                  thinkingContent.text += msg.payload.text;
+                  setMessages(prev => {
+                    const filtered = prev.filter(m => m.id !== currentMessageRef.current.id);
+                    return [...filtered, { ...currentMessageRef.current }];
+                  });
+                }
+              }
+              break;
+
+            case 'tool_use_start':
+              if (currentMessageRef.current) {
+                currentMessageRef.current.content.push({
+                  type: 'tool_use',
+                  id: msg.payload.toolUseId,
+                  name: msg.payload.toolName,
+                  input: msg.payload.input,
+                  status: 'running'
+                });
+                setMessages(prev => {
+                  const filtered = prev.filter(m => m.id !== currentMessageRef.current.id);
+                  return [...filtered, { ...currentMessageRef.current }];
+                });
+                setStatus('tool_executing');
+              }
+              break;
+
+            case 'tool_result':
+              if (currentMessageRef.current) {
+                const toolUse = currentMessageRef.current.content.find(
+                  c => c.type === 'tool_use' && c.id === msg.payload.toolUseId
+                );
+                if (toolUse) {
+                  toolUse.status = msg.payload.success ? 'completed' : 'error';
+                  toolUse.result = {
+                    success: msg.payload.success,
+                    output: msg.payload.output,
+                    error: msg.payload.error
+                  };
+                  setMessages(prev => {
+                    const filtered = prev.filter(m => m.id !== currentMessageRef.current.id);
+                    return [...filtered, { ...currentMessageRef.current }];
+                  });
+                }
+              }
+              break;
+
+            case 'message_complete':
+              if (currentMessageRef.current) {
+                currentMessageRef.current.usage = msg.payload.usage;
+                setMessages(prev => {
+                  const filtered = prev.filter(m => m.id !== currentMessageRef.current.id);
+                  return [...filtered, { ...currentMessageRef.current }];
+                });
+                currentMessageRef.current = null;
+              }
+              setStatus('idle');
+              break;
+
+            case 'error':
+              console.error('Server error:', msg.payload);
+              setStatus('idle');
+              break;
+
+            case 'status':
+              setStatus(msg.payload.status);
+              break;
+          }
+        });
+
+        return unsubscribe;
+      }, [addMessageHandler, model]);
+
+      // 自动滚动到底部
+      useEffect(() => {
+        if (chatContainerRef.current) {
+          chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight;
+        }
+      }, [messages]);
+
+      const handleSend = () => {
+        if (!input.trim() || !connected || status !== 'idle') return;
+
+        const userMessage = {
+          id: 'user-' + Date.now(),
+          role: 'user',
+          timestamp: Date.now(),
+          content: [{ type: 'text', text: input }]
+        };
+
+        setMessages(prev => [...prev, userMessage]);
+        send({ type: 'chat', payload: { content: input } });
+        setInput('');
+        setStatus('thinking');
+      };
+
+      const handleKeyDown = (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          handleSend();
+        }
+      };
+
+      return React.createElement('div', { id: 'root' },
+        // 侧边栏
+        React.createElement('div', { className: 'sidebar' },
+          React.createElement('div', { className: 'sidebar-header' },
+            React.createElement('h1', null, '🤖 Claude Code'),
+            React.createElement('button', {
+              className: 'new-chat-btn',
+              onClick: () => {
+                setMessages([]);
+                send({ type: 'clear_history' });
+              }
+            }, '+ 新对话')
+          ),
+          React.createElement('div', { className: 'session-list' }),
+          React.createElement('div', { className: 'sidebar-footer' },
+            React.createElement('div', { className: 'status-indicator' },
+              React.createElement('span', {
+                className: \`status-dot \${status === 'idle' ? '' : 'thinking'}\`
+              }),
+              connected ? '已连接' : '连接中...'
+            ),
+            sessionId && React.createElement('div', null, \`会话: \${sessionId.slice(0, 8)}...\`)
+          )
+        ),
+        // 主内容区
+        React.createElement('div', { className: 'main-content' },
+          React.createElement('div', { className: 'chat-header' },
+            React.createElement('div', null, '对话'),
+            React.createElement('select', {
+              className: 'model-selector',
+              value: model,
+              onChange: (e) => send({ type: 'set_model', payload: { model: e.target.value } })
+            },
+              React.createElement('option', { value: 'opus' }, 'Claude Opus'),
+              React.createElement('option', { value: 'sonnet' }, 'Claude Sonnet'),
+              React.createElement('option', { value: 'haiku' }, 'Claude Haiku')
+            )
+          ),
+          React.createElement('div', {
+            className: 'chat-container',
+            ref: chatContainerRef
+          },
+            messages.length === 0
+              ? React.createElement(WelcomeScreen)
+              : messages.map(msg => React.createElement(Message, { key: msg.id, message: msg }))
+          ),
+          React.createElement('div', { className: 'input-area' },
+            React.createElement('div', { className: 'input-container' },
+              React.createElement('div', { className: 'input-wrapper' },
+                React.createElement('textarea', {
+                  ref: inputRef,
+                  className: 'chat-input',
+                  value: input,
+                  onChange: (e) => setInput(e.target.value),
+                  onKeyDown: handleKeyDown,
+                  placeholder: status === 'idle' ? '输入消息...' : '处理中...',
+                  disabled: status !== 'idle',
+                  rows: 1
+                })
+              ),
+              React.createElement('button', {
+                className: 'send-btn',
+                onClick: handleSend,
+                disabled: !connected || status !== 'idle' || !input.trim()
+              },
+                status !== 'idle'
+                  ? React.createElement('div', { className: 'loading-dots' },
+                      React.createElement('span'),
+                      React.createElement('span'),
+                      React.createElement('span')
+                    )
+                  : '发送'
+              )
+            )
+          )
+        )
+      );
+    }
+
+    // 渲染应用
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(React.createElement(App));
+  `;
+}
+
+// 如果直接运行此文件，启动服务器
+const isMainModule = process.argv[1]?.includes('server') ||
+                     process.argv[1]?.endsWith('web.js') ||
+                     process.argv[1]?.endsWith('web.ts');
+
+if (isMainModule) {
+  startWebServer().catch(console.error);
+}

--- a/src/web/server/routes/api.ts
+++ b/src/web/server/routes/api.ts
@@ -1,0 +1,91 @@
+/**
+ * REST API 路由
+ */
+
+import type { Express, Request, Response } from 'express';
+import type { ConversationManager } from '../conversation.js';
+import { toolRegistry } from '../../../tools/index.js';
+
+export function setupApiRoutes(app: Express, conversationManager: ConversationManager): void {
+  // 健康检查
+  app.get('/api/health', (req: Request, res: Response) => {
+    res.json({
+      status: 'ok',
+      timestamp: Date.now(),
+      version: '2.0.76',
+    });
+  });
+
+  // 获取可用工具列表
+  app.get('/api/tools', (req: Request, res: Response) => {
+    const tools = toolRegistry.getAll().map(tool => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.getInputSchema(),
+    }));
+
+    res.json({
+      count: tools.length,
+      tools,
+    });
+  });
+
+  // 获取模型列表
+  app.get('/api/models', (req: Request, res: Response) => {
+    res.json({
+      models: [
+        {
+          id: 'opus',
+          name: 'Claude Opus',
+          description: '最强大的模型，适合复杂任务',
+          modelId: 'claude-opus-4-20250514',
+        },
+        {
+          id: 'sonnet',
+          name: 'Claude Sonnet',
+          description: '平衡性能和速度',
+          modelId: 'claude-sonnet-4-20250514',
+        },
+        {
+          id: 'haiku',
+          name: 'Claude Haiku',
+          description: '最快速的模型',
+          modelId: 'claude-3-5-haiku-20241022',
+        },
+      ],
+    });
+  });
+
+  // 获取会话信息
+  app.get('/api/session/:sessionId', (req: Request, res: Response) => {
+    const { sessionId } = req.params;
+    const history = conversationManager.getHistory(sessionId);
+
+    res.json({
+      sessionId,
+      messageCount: history.length,
+      history,
+    });
+  });
+
+  // 清除会话
+  app.delete('/api/session/:sessionId', (req: Request, res: Response) => {
+    const { sessionId } = req.params;
+    conversationManager.clearHistory(sessionId);
+
+    res.json({
+      success: true,
+      message: '会话已清除',
+    });
+  });
+
+  // 获取工作目录信息
+  app.get('/api/cwd', (req: Request, res: Response) => {
+    res.json({
+      cwd: process.cwd(),
+    });
+  });
+
+  // 注意：Express 5 不再支持 /api/* 这样的通配符路由
+  // 404 处理将由主路由的 SPA fallback 处理
+}

--- a/src/web/server/websocket.ts
+++ b/src/web/server/websocket.ts
@@ -1,0 +1,281 @@
+/**
+ * WebSocket 处理器
+ * 处理实时双向通信
+ */
+
+import { WebSocketServer, WebSocket } from 'ws';
+import { randomUUID } from 'crypto';
+import { ConversationManager } from './conversation.js';
+import type { ClientMessage, ServerMessage } from '../shared/types.js';
+
+interface ClientConnection {
+  id: string;
+  ws: WebSocket;
+  sessionId: string;
+  model: string;
+  isAlive: boolean;
+}
+
+export function setupWebSocket(
+  wss: WebSocketServer,
+  conversationManager: ConversationManager
+): void {
+  const clients = new Map<string, ClientConnection>();
+
+  // 心跳检测
+  const heartbeatInterval = setInterval(() => {
+    clients.forEach((client, id) => {
+      if (!client.isAlive) {
+        client.ws.terminate();
+        clients.delete(id);
+        return;
+      }
+      client.isAlive = false;
+      client.ws.ping();
+    });
+  }, 30000);
+
+  wss.on('close', () => {
+    clearInterval(heartbeatInterval);
+  });
+
+  wss.on('connection', (ws: WebSocket) => {
+    const clientId = randomUUID();
+    const sessionId = randomUUID();
+
+    const client: ClientConnection = {
+      id: clientId,
+      ws,
+      sessionId,
+      model: 'sonnet',
+      isAlive: true,
+    };
+
+    clients.set(clientId, client);
+
+    console.log(`[WebSocket] 客户端连接: ${clientId}`);
+
+    // 发送连接确认
+    sendMessage(ws, {
+      type: 'connected',
+      payload: {
+        sessionId,
+        model: client.model,
+      },
+    });
+
+    // 处理心跳
+    ws.on('pong', () => {
+      client.isAlive = true;
+    });
+
+    // 处理消息
+    ws.on('message', async (data: Buffer) => {
+      try {
+        const message: ClientMessage = JSON.parse(data.toString());
+        await handleClientMessage(client, message, conversationManager);
+      } catch (error) {
+        console.error('[WebSocket] 消息处理错误:', error);
+        sendMessage(ws, {
+          type: 'error',
+          payload: {
+            message: error instanceof Error ? error.message : '未知错误',
+          },
+        });
+      }
+    });
+
+    // 处理关闭
+    ws.on('close', () => {
+      console.log(`[WebSocket] 客户端断开: ${clientId}`);
+      clients.delete(clientId);
+    });
+
+    // 处理错误
+    ws.on('error', (error) => {
+      console.error(`[WebSocket] 客户端错误 ${clientId}:`, error);
+      clients.delete(clientId);
+    });
+  });
+}
+
+/**
+ * 发送消息到客户端
+ */
+function sendMessage(ws: WebSocket, message: ServerMessage): void {
+  if (ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify(message));
+  }
+}
+
+/**
+ * 处理客户端消息
+ */
+async function handleClientMessage(
+  client: ClientConnection,
+  message: ClientMessage,
+  conversationManager: ConversationManager
+): Promise<void> {
+  const { ws } = client;
+
+  switch (message.type) {
+    case 'ping':
+      sendMessage(ws, { type: 'pong' });
+      break;
+
+    case 'chat':
+      await handleChatMessage(client, message.payload.content, message.payload.images, conversationManager);
+      break;
+
+    case 'cancel':
+      conversationManager.cancel(client.sessionId);
+      sendMessage(ws, {
+        type: 'status',
+        payload: { status: 'idle', message: '已取消' },
+      });
+      break;
+
+    case 'get_history':
+      const history = conversationManager.getHistory(client.sessionId);
+      sendMessage(ws, {
+        type: 'history',
+        payload: { messages: history },
+      });
+      break;
+
+    case 'clear_history':
+      conversationManager.clearHistory(client.sessionId);
+      sendMessage(ws, {
+        type: 'history',
+        payload: { messages: [] },
+      });
+      break;
+
+    case 'set_model':
+      client.model = message.payload.model;
+      conversationManager.setModel(client.sessionId, message.payload.model);
+      break;
+
+    default:
+      console.warn('[WebSocket] 未知消息类型:', (message as any).type);
+  }
+}
+
+/**
+ * 处理聊天消息
+ */
+async function handleChatMessage(
+  client: ClientConnection,
+  content: string,
+  images: string[] | undefined,
+  conversationManager: ConversationManager
+): Promise<void> {
+  const { ws, sessionId, model } = client;
+  const messageId = randomUUID();
+
+  // 发送消息开始
+  sendMessage(ws, {
+    type: 'message_start',
+    payload: { messageId },
+  });
+
+  // 发送状态更新
+  sendMessage(ws, {
+    type: 'status',
+    payload: { status: 'thinking' },
+  });
+
+  try {
+    // 调用对话管理器，传入流式回调
+    await conversationManager.chat(sessionId, content, images, model, {
+      onThinkingStart: () => {
+        sendMessage(ws, {
+          type: 'thinking_start',
+          payload: { messageId },
+        });
+      },
+
+      onThinkingDelta: (text: string) => {
+        sendMessage(ws, {
+          type: 'thinking_delta',
+          payload: { messageId, text },
+        });
+      },
+
+      onThinkingComplete: () => {
+        sendMessage(ws, {
+          type: 'thinking_complete',
+          payload: { messageId },
+        });
+      },
+
+      onTextDelta: (text: string) => {
+        sendMessage(ws, {
+          type: 'text_delta',
+          payload: { messageId, text },
+        });
+      },
+
+      onToolUseStart: (toolUseId: string, toolName: string, input: unknown) => {
+        sendMessage(ws, {
+          type: 'tool_use_start',
+          payload: { messageId, toolUseId, toolName, input },
+        });
+        sendMessage(ws, {
+          type: 'status',
+          payload: { status: 'tool_executing', message: `执行 ${toolName}...` },
+        });
+      },
+
+      onToolUseDelta: (toolUseId: string, partialJson: string) => {
+        sendMessage(ws, {
+          type: 'tool_use_delta',
+          payload: { toolUseId, partialJson },
+        });
+      },
+
+      onToolResult: (toolUseId: string, success: boolean, output?: string, error?: string, data?: unknown) => {
+        sendMessage(ws, {
+          type: 'tool_result',
+          payload: { toolUseId, success, output, error, data } as any,
+        });
+      },
+
+      onComplete: (stopReason: string | null, usage?: { inputTokens: number; outputTokens: number }) => {
+        sendMessage(ws, {
+          type: 'message_complete',
+          payload: {
+            messageId,
+            stopReason: stopReason as any,
+            usage,
+          },
+        });
+        sendMessage(ws, {
+          type: 'status',
+          payload: { status: 'idle' },
+        });
+      },
+
+      onError: (error: Error) => {
+        sendMessage(ws, {
+          type: 'error',
+          payload: { message: error.message },
+        });
+        sendMessage(ws, {
+          type: 'status',
+          payload: { status: 'idle' },
+        });
+      },
+    });
+  } catch (error) {
+    console.error('[WebSocket] 聊天处理错误:', error);
+    sendMessage(ws, {
+      type: 'error',
+      payload: { message: error instanceof Error ? error.message : '处理失败' },
+    });
+    sendMessage(ws, {
+      type: 'status',
+      payload: { status: 'idle' },
+    });
+  }
+}

--- a/src/web/shared/types.ts
+++ b/src/web/shared/types.ts
@@ -1,0 +1,349 @@
+/**
+ * WebUI 共享类型定义
+ * 前后端通用的类型
+ */
+
+// ============ WebSocket 消息类型 ============
+
+/**
+ * WebSocket 消息基础接口
+ */
+export interface WSMessage {
+  type: string;
+  payload?: unknown;
+}
+
+/**
+ * 客户端发送的消息类型
+ */
+export type ClientMessage =
+  | { type: 'chat'; payload: { content: string; images?: string[] } }
+  | { type: 'cancel' }
+  | { type: 'ping' }
+  | { type: 'get_history' }
+  | { type: 'clear_history' }
+  | { type: 'set_model'; payload: { model: string } };
+
+/**
+ * 服务端发送的消息类型
+ */
+export type ServerMessage =
+  | { type: 'connected'; payload: { sessionId: string; model: string } }
+  | { type: 'pong' }
+  | { type: 'history'; payload: { messages: ChatMessage[] } }
+  | { type: 'message_start'; payload: { messageId: string } }
+  | { type: 'text_delta'; payload: { messageId: string; text: string } }
+  | { type: 'tool_use_start'; payload: ToolUseStartPayload }
+  | { type: 'tool_use_delta'; payload: { toolUseId: string; partialJson: string } }
+  | { type: 'tool_result'; payload: ToolResultPayload }
+  | { type: 'message_complete'; payload: MessageCompletePayload }
+  | { type: 'error'; payload: { message: string; code?: string } }
+  | { type: 'thinking_start'; payload: { messageId: string } }
+  | { type: 'thinking_delta'; payload: { messageId: string; text: string } }
+  | { type: 'thinking_complete'; payload: { messageId: string } }
+  | { type: 'status'; payload: StatusPayload };
+
+// ============ 消息负载类型 ============
+
+export interface ToolUseStartPayload {
+  messageId: string;
+  toolUseId: string;
+  toolName: string;
+  input: unknown;
+}
+
+export interface ToolResultPayload {
+  toolUseId: string;
+  success: boolean;
+  output?: string;
+  error?: string;
+  /** 工具特定的结构化数据 */
+  data?: ToolResultData;
+}
+
+export interface MessageCompletePayload {
+  messageId: string;
+  stopReason: 'end_turn' | 'max_tokens' | 'stop_sequence' | 'tool_use' | null;
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+  };
+}
+
+export interface StatusPayload {
+  status: 'idle' | 'thinking' | 'tool_executing' | 'streaming';
+  message?: string;
+}
+
+// ============ 聊天消息类型 ============
+
+/**
+ * 聊天消息
+ */
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  timestamp: number;
+  content: ChatContent[];
+  /** 仅助手消息有 */
+  model?: string;
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+  };
+}
+
+/**
+ * 聊天内容块
+ */
+export type ChatContent =
+  | TextContent
+  | ImageContent
+  | ToolUseContent
+  | ToolResultContent
+  | ThinkingContent;
+
+export interface TextContent {
+  type: 'text';
+  text: string;
+}
+
+export interface ImageContent {
+  type: 'image';
+  mediaType: string;
+  data: string; // base64
+}
+
+export interface ThinkingContent {
+  type: 'thinking';
+  text: string;
+}
+
+export interface ToolUseContent {
+  type: 'tool_use';
+  id: string;
+  name: string;
+  input: unknown;
+  /** 执行状态 */
+  status: 'pending' | 'running' | 'completed' | 'error';
+  /** 关联的结果 */
+  result?: ToolResultContent;
+}
+
+export interface ToolResultContent {
+  type: 'tool_result';
+  toolUseId: string;
+  success: boolean;
+  output?: string;
+  error?: string;
+  /** 结构化数据用于特殊渲染 */
+  data?: ToolResultData;
+}
+
+// ============ 工具结果数据类型 ============
+
+/**
+ * 工具特定的结构化结果数据
+ * 用于前端特殊渲染
+ */
+export type ToolResultData =
+  | BashResultData
+  | ReadResultData
+  | WriteResultData
+  | EditResultData
+  | GlobResultData
+  | GrepResultData
+  | WebFetchResultData
+  | WebSearchResultData
+  | TodoResultData
+  | DiffResultData
+  | TaskResultData;
+
+export interface BashResultData {
+  tool: 'Bash';
+  command: string;
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+  duration?: number;
+}
+
+export interface ReadResultData {
+  tool: 'Read';
+  filePath: string;
+  content: string;
+  lineCount: number;
+  language?: string;
+}
+
+export interface WriteResultData {
+  tool: 'Write';
+  filePath: string;
+  bytesWritten: number;
+}
+
+export interface EditResultData {
+  tool: 'Edit';
+  filePath: string;
+  diff: DiffHunk[];
+  linesAdded: number;
+  linesRemoved: number;
+}
+
+export interface DiffHunk {
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+  lines: DiffLine[];
+}
+
+export interface DiffLine {
+  type: 'add' | 'remove' | 'context';
+  content: string;
+  oldLineNumber?: number;
+  newLineNumber?: number;
+}
+
+export interface GlobResultData {
+  tool: 'Glob';
+  pattern: string;
+  files: string[];
+  totalCount: number;
+}
+
+export interface GrepResultData {
+  tool: 'Grep';
+  pattern: string;
+  matches: GrepMatch[];
+  totalCount: number;
+}
+
+export interface GrepMatch {
+  file: string;
+  line: number;
+  content: string;
+  context?: {
+    before: string[];
+    after: string[];
+  };
+}
+
+export interface WebFetchResultData {
+  tool: 'WebFetch';
+  url: string;
+  title?: string;
+  contentPreview?: string;
+}
+
+export interface WebSearchResultData {
+  tool: 'WebSearch';
+  query: string;
+  results: SearchResult[];
+}
+
+export interface SearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+export interface TodoResultData {
+  tool: 'TodoWrite';
+  todos: TodoItem[];
+}
+
+export interface TodoItem {
+  content: string;
+  status: 'pending' | 'in_progress' | 'completed';
+  activeForm?: string;
+}
+
+export interface DiffResultData {
+  tool: 'Diff';
+  hunks: DiffHunk[];
+}
+
+export interface TaskResultData {
+  tool: 'Task';
+  agentType: string;
+  description: string;
+  status: 'running' | 'completed' | 'error';
+  output?: string;
+}
+
+// ============ 会话信息 ============
+
+export interface SessionInfo {
+  id: string;
+  createdAt: number;
+  lastActiveAt: number;
+  model: string;
+  messageCount: number;
+  totalCost: number;
+  cwd: string;
+}
+
+// ============ 工具名称映射 ============
+
+export const TOOL_DISPLAY_NAMES: Record<string, string> = {
+  Bash: '终端命令',
+  BashOutput: '终端输出',
+  KillShell: '终止进程',
+  Read: '读取文件',
+  Write: '写入文件',
+  Edit: '编辑文件',
+  MultiEdit: '批量编辑',
+  Glob: '文件搜索',
+  Grep: '内容搜索',
+  WebFetch: '网页获取',
+  WebSearch: '网页搜索',
+  TodoWrite: '任务管理',
+  Task: '子任务',
+  TaskOutput: '任务输出',
+  ListAgents: '代理列表',
+  NotebookEdit: '笔记本编辑',
+  EnterPlanMode: '进入计划模式',
+  ExitPlanMode: '退出计划模式',
+  ListMcpResources: 'MCP资源列表',
+  ReadMcpResource: '读取MCP资源',
+  MCPSearch: 'MCP搜索',
+  AskUserQuestion: '询问用户',
+  Tmux: '终端复用',
+  Skill: '技能',
+  SlashCommand: '斜杠命令',
+  LSP: '语言服务',
+  Chrome: 'Chrome调试',
+};
+
+// ============ 工具图标映射 ============
+
+export const TOOL_ICONS: Record<string, string> = {
+  Bash: '💻',
+  BashOutput: '📤',
+  KillShell: '🛑',
+  Read: '📖',
+  Write: '✏️',
+  Edit: '🔧',
+  MultiEdit: '📝',
+  Glob: '🔍',
+  Grep: '🔎',
+  WebFetch: '🌐',
+  WebSearch: '🔍',
+  TodoWrite: '✅',
+  Task: '🤖',
+  TaskOutput: '📋',
+  ListAgents: '👥',
+  NotebookEdit: '📓',
+  EnterPlanMode: '📋',
+  ExitPlanMode: '✅',
+  ListMcpResources: '📦',
+  ReadMcpResource: '📄',
+  MCPSearch: '🔍',
+  AskUserQuestion: '❓',
+  Tmux: '🖥️',
+  Skill: '⚡',
+  SlashCommand: '/',
+  LSP: '🔤',
+  Chrome: '🌐',
+};


### PR DESCRIPTION
添加基于 Web 的用户界面，支持在浏览器中与 Claude Code 交互。

功能特性：
- Express + WebSocket 服务器架构
- 实时流式消息响应
- 支持所有 27 个工具的渲染
- 工具调用可折叠展示
- Markdown 渲染和代码高亮
- 深色主题 UI
- 模型切换支持 (Opus/Sonnet/Haiku)
- 思考过程显示

使用方式：
- npm run web - 启动 WebUI 服务器
- 默认地址: http://localhost:3456

技术栈：
- 后端: Express 5 + WebSocket (ws)
- 前端: React 18 (内联 CDN)
- 通信: JSON over WebSocket

🤖 Generated with [Claude Code](https://claude.ai/code)