### PR TITLE
Refactor Map Serve architecture with distributed storage

### DIFF
--- a/src/map/server/static/app.js
+++ b/src/map/server/static/app.js
@@ -2967,4 +2967,196 @@
     });
 
     // 初始化
-    loadOntology();
+    loadOntology();
+
+    // ============ 设计驱动功能 ============
+
+    // 当前操作的目录路径
+    let currentDirPath = '';
+
+    // 打开添加计划模块对话框
+    window.openPlannedModuleModal = function(dirPath) {
+      currentDirPath = dirPath || '';
+      document.getElementById('add-planned-module-modal').style.display = 'flex';
+      document.getElementById('planned-module-id').value = dirPath ? `${dirPath}/` : '';
+      document.getElementById('planned-module-name').value = '';
+      document.getElementById('planned-module-notes').value = '';
+      document.getElementById('planned-module-deps').value = '';
+    };
+
+    window.closePlannedModuleModal = function() {
+      document.getElementById('add-planned-module-modal').style.display = 'none';
+    };
+
+    // 提交计划模块
+    window.submitPlannedModule = async function(event) {
+      event.preventDefault();
+
+      const form = event.target;
+      const formData = new FormData(form);
+
+      const moduleId = formData.get('id');
+      const dirPath = moduleId.includes('/') ? moduleId.substring(0, moduleId.lastIndexOf('/')) : '';
+
+      const moduleData = {
+        id: moduleId,
+        name: formData.get('name') || moduleId.split('/').pop(),
+        status: 'planned',
+        designNotes: formData.get('designNotes'),
+        priority: formData.get('priority'),
+        dependencies: formData.get('dependencies')
+          ? formData.get('dependencies').split(',').map(d => d.trim()).filter(d => d)
+          : [],
+      };
+
+      try {
+        const response = await fetch('/api/module/planned', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ dirPath, moduleData }),
+        });
+
+        const result = await response.json();
+
+        if (result.success) {
+          window.showToast('✓ 计划模块已添加');
+          window.closePlannedModuleModal();
+          // 清除缓存并刷新视图
+          const chunkPath = dirPath === '' ? 'root' : dirPath.replace(/[/\\]/g, '_');
+          window.chunkCache.delete(chunkPath);
+          // 刷新当前视图
+          if (typeof window.drawArchitectureFromIndex === 'function') {
+            window.drawArchitectureFromIndex();
+          }
+        } else {
+          alert('添加失败: ' + result.error);
+        }
+      } catch (error) {
+        alert('请求失败: ' + error.message);
+      }
+
+      return false;
+    };
+
+    // 打开重构任务对话框
+    window.openRefactoringModal = function(moduleId) {
+      document.getElementById('refactoring-target').value = moduleId;
+      document.getElementById('add-refactoring-modal').style.display = 'flex';
+      document.getElementById('refactoring-reason').value = '';
+      document.getElementById('refactoring-description').value = '';
+    };
+
+    window.closeRefactoringModal = function() {
+      document.getElementById('add-refactoring-modal').style.display = 'none';
+    };
+
+    // 提交重构任务
+    window.submitRefactoringTask = async function(event) {
+      event.preventDefault();
+
+      const form = event.target;
+      const formData = new FormData(form);
+
+      const target = formData.get('target');
+      const dirPath = target.includes('/') ? target.substring(0, target.lastIndexOf('/')) : '';
+
+      const task = {
+        target: target,
+        type: formData.get('type'),
+        reason: formData.get('reason'),
+        description: formData.get('description') || formData.get('reason'),
+        priority: formData.get('priority'),
+      };
+
+      try {
+        const response = await fetch('/api/refactoring-task', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ dirPath, task }),
+        });
+
+        const result = await response.json();
+
+        if (result.success) {
+          window.showToast('✓ 重构任务已添加');
+          window.closeRefactoringModal();
+          // 清除缓存
+          const chunkPath = dirPath === '' ? 'root' : dirPath.replace(/[/\\]/g, '_');
+          window.chunkCache.delete(chunkPath);
+        } else {
+          alert('添加失败: ' + result.error);
+        }
+      } catch (error) {
+        alert('请求失败: ' + error.message);
+      }
+
+      return false;
+    };
+
+    // 打开设计编辑对话框
+    window.openDesignModal = function(moduleId, currentStatus, currentNotes) {
+      document.getElementById('design-module-id').value = moduleId;
+      document.getElementById('design-module-path').textContent = moduleId;
+      document.getElementById('design-status').value = currentStatus || 'implemented';
+      document.getElementById('design-notes').value = currentNotes || '';
+      document.getElementById('edit-design-modal').style.display = 'flex';
+    };
+
+    window.closeDesignModal = function() {
+      document.getElementById('edit-design-modal').style.display = 'none';
+    };
+
+    // 提交设计编辑
+    window.submitDesignEdit = async function(event) {
+      event.preventDefault();
+
+      const form = event.target;
+      const formData = new FormData(form);
+
+      const moduleId = formData.get('moduleId');
+
+      try {
+        const response = await fetch(`/api/module-design?id=${encodeURIComponent(moduleId)}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            status: formData.get('status'),
+            designNotes: formData.get('designNotes'),
+          }),
+        });
+
+        const result = await response.json();
+
+        if (result.success) {
+          window.showToast('✓ 设计已保存');
+          window.closeDesignModal();
+          // 清除缓存
+          const dirPath = moduleId.includes('/') ? moduleId.substring(0, moduleId.lastIndexOf('/')) : '';
+          const chunkPath = dirPath === '' ? 'root' : dirPath.replace(/[/\\]/g, '_');
+          window.chunkCache.delete(chunkPath);
+        } else {
+          alert('保存失败: ' + result.error);
+        }
+      } catch (error) {
+        alert('请求失败: ' + error.message);
+      }
+
+      return false;
+    };
+
+    // 显示 Toast 通知
+    window.showToast = function(message) {
+      const existing = document.querySelector('.toast');
+      if (existing) {
+        existing.remove();
+      }
+
+      const toast = document.createElement('div');
+      toast.className = 'toast';
+      toast.textContent = message;
+      document.body.appendChild(toast);
+
+      setTimeout(() => {
+        toast.remove();
+      }, 3000);
+    };

--- a/src/map/server/static/chunked-loader.js
+++ b/src/map/server/static/chunked-loader.js
@@ -251,13 +251,33 @@
     let html = `<h3>${layerName}</h3>`;
     html += `<div style="color: #888; margin-bottom: 1rem;">共 ${modulesArray.length} 个模块</div>`;
 
+    // 添加"添加计划模块"按钮
+    html += `<button class="add-planned-btn" onclick="openPlannedModuleModal('')">+ 添加计划模块</button>`;
+
     modulesArray.forEach(module => {
-      html += `<div class="module-item" style="cursor: pointer; padding: 0.5rem; margin: 0.3rem 0; background: #16213e; border-radius: 4px;" onclick="showModuleDetailsFromChunk('${module.id}')">`;
-      html += `<div style="color: #4ecdc4; font-weight: bold;">${module.name}</div>`;
-      html += `<div style="color: #888; font-size: 0.85rem;">${module.path}</div>`;
+      const status = module.designMeta?.status || 'implemented';
+      const statusClass = status.replace('-', '');
+      const statusText = {
+        'implemented': '已实现',
+        'planned': '计划中',
+        'in-progress': '开发中',
+        'needs-refactor': '需重构',
+        'deprecated': '已废弃'
+      }[status] || status;
+
+      html += `<div class="module-item" style="padding: 0.75rem; margin: 0.5rem 0; background: #16213e; border-radius: 4px; border-left: 3px solid ${status === 'needs-refactor' ? '#e94560' : '#4ecdc4'};">`;
+      html += `<div style="display: flex; justify-content: space-between; align-items: center;">`;
+      html += `<div style="color: #4ecdc4; font-weight: bold; cursor: pointer;" onclick="showModuleDetailsFromChunk('${module.id}')">${module.name}</div>`;
+      html += `<span class="status-badge ${statusClass}">${statusText}</span>`;
+      html += `</div>`;
+      html += `<div style="color: #888; font-size: 0.85rem; margin-top: 0.25rem;">${module.path}</div>`;
       if (module.lines) {
         html += `<div style="color: #aaa; font-size: 0.8rem;">${module.lines} 行</div>`;
       }
+      html += `<div class="module-actions">`;
+      html += `<button onclick="openDesignModal('${module.id}', '${status}', '')">✏️ 编辑</button>`;
+      html += `<button onclick="openRefactoringModal('${module.id}')">🔧 重构</button>`;
+      html += `</div>`;
       html += '</div>';
     });
 

--- a/src/map/server/static/index.html
+++ b/src/map/server/static/index.html
@@ -210,6 +210,126 @@
     </div>
   </div>
 
+  <!-- 添加计划模块对话框 -->
+  <div class="modal" id="add-planned-module-modal" style="display:none">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3>添加计划模块</h3>
+        <button class="modal-close" onclick="closePlannedModuleModal()">×</button>
+      </div>
+      <form id="add-planned-module-form" onsubmit="return submitPlannedModule(event)">
+        <div class="form-group">
+          <label for="planned-module-id">模块路径：</label>
+          <input type="text" id="planned-module-id" name="id" placeholder="src/core/retry.ts" required>
+        </div>
+        <div class="form-group">
+          <label for="planned-module-name">模块名称：</label>
+          <input type="text" id="planned-module-name" name="name" placeholder="retry.ts">
+        </div>
+        <div class="form-group">
+          <label for="planned-module-notes">功能描述：</label>
+          <textarea id="planned-module-notes" name="designNotes" rows="3" placeholder="描述这个模块的功能..." required></textarea>
+        </div>
+        <div class="form-group">
+          <label for="planned-module-priority">优先级：</label>
+          <select id="planned-module-priority" name="priority">
+            <option value="high">高</option>
+            <option value="medium" selected>中</option>
+            <option value="low">低</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="planned-module-deps">依赖模块（逗号分隔）：</label>
+          <input type="text" id="planned-module-deps" name="dependencies" placeholder="src/core/client.ts, src/utils/index.ts">
+        </div>
+        <div class="form-actions">
+          <button type="button" onclick="closePlannedModuleModal()">取消</button>
+          <button type="submit" class="primary">保存到蓝图</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <!-- 添加重构任务对话框 -->
+  <div class="modal" id="add-refactoring-modal" style="display:none">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3>标记重构任务</h3>
+        <button class="modal-close" onclick="closeRefactoringModal()">×</button>
+      </div>
+      <form id="add-refactoring-form" onsubmit="return submitRefactoringTask(event)">
+        <input type="hidden" id="refactoring-target" name="target">
+        <div class="form-group">
+          <label for="refactoring-type">重构类型：</label>
+          <select id="refactoring-type" name="type" required>
+            <option value="extract-function">提取函数</option>
+            <option value="extract-class">提取类</option>
+            <option value="rename">重命名</option>
+            <option value="move">移动模块</option>
+            <option value="split">拆分模块</option>
+            <option value="merge">合并模块</option>
+            <option value="inline">内联</option>
+            <option value="other">其他</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="refactoring-reason">重构原因：</label>
+          <textarea id="refactoring-reason" name="reason" rows="2" placeholder="为什么需要重构..." required></textarea>
+        </div>
+        <div class="form-group">
+          <label for="refactoring-description">描述：</label>
+          <textarea id="refactoring-description" name="description" rows="3" placeholder="详细描述重构内容..."></textarea>
+        </div>
+        <div class="form-group">
+          <label for="refactoring-priority">优先级：</label>
+          <select id="refactoring-priority" name="priority">
+            <option value="high">高</option>
+            <option value="medium" selected>中</option>
+            <option value="low">低</option>
+          </select>
+        </div>
+        <div class="form-actions">
+          <button type="button" onclick="closeRefactoringModal()">取消</button>
+          <button type="submit" class="primary">添加任务</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <!-- 模块设计编辑对话框 -->
+  <div class="modal" id="edit-design-modal" style="display:none">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3>编辑模块设计</h3>
+        <button class="modal-close" onclick="closeDesignModal()">×</button>
+      </div>
+      <form id="edit-design-form" onsubmit="return submitDesignEdit(event)">
+        <input type="hidden" id="design-module-id" name="moduleId">
+        <div class="form-group">
+          <label>模块路径：</label>
+          <div id="design-module-path" style="color: #4ecdc4; padding: 0.5rem 0;"></div>
+        </div>
+        <div class="form-group">
+          <label for="design-status">状态：</label>
+          <select id="design-status" name="status">
+            <option value="implemented">已实现</option>
+            <option value="in-progress">开发中</option>
+            <option value="needs-refactor">需要重构</option>
+            <option value="deprecated">已废弃</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="design-notes">设计备注：</label>
+          <textarea id="design-notes" name="designNotes" rows="4" placeholder="记录设计决策、待办事项等..."></textarea>
+        </div>
+        <div class="form-actions">
+          <button type="button" onclick="closeDesignModal()">取消</button>
+          <button type="submit" class="primary">保存</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
   <script src="chunked-loader.js"></script>
   <script src="app.js"></script>
 </body>

--- a/src/map/server/static/styles.css
+++ b/src/map/server/static/styles.css
@@ -2069,3 +2069,181 @@
     .symbol-badge.interface { color: #4ec9b0; }
     .symbol-badge.variable { color: #9cdcfe; }
     .symbol-badge.type { color: #4ec9b0; }
+
+    /* ========================================
+       设计驱动开发 - 模态框样式
+       ======================================== */
+    /* 模态框样式 */
+    .modal {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.7);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+    }
+
+    .modal-content {
+      background: #1a1a2e;
+      border: 1px solid #4ecdc4;
+      border-radius: 8px;
+      width: 90%;
+      max-width: 500px;
+      max-height: 90vh;
+      overflow-y: auto;
+    }
+
+    .modal-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem;
+      border-bottom: 1px solid #333;
+    }
+
+    .modal-header h3 {
+      margin: 0;
+      color: #4ecdc4;
+    }
+
+    .modal-close {
+      background: none;
+      border: none;
+      color: #888;
+      font-size: 1.5rem;
+      cursor: pointer;
+    }
+
+    .modal-close:hover {
+      color: #e94560;
+    }
+
+    .form-group {
+      padding: 0.75rem 1rem;
+    }
+
+    .form-group label {
+      display: block;
+      margin-bottom: 0.5rem;
+      color: #aaa;
+    }
+
+    .form-group input,
+    .form-group textarea,
+    .form-group select {
+      width: 100%;
+      padding: 0.5rem;
+      background: #16213e;
+      border: 1px solid #333;
+      border-radius: 4px;
+      color: #fff;
+      font-size: 0.9rem;
+    }
+
+    .form-group textarea {
+      resize: vertical;
+    }
+
+    .form-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.5rem;
+      padding: 1rem;
+      border-top: 1px solid #333;
+    }
+
+    .form-actions button {
+      padding: 0.5rem 1rem;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+
+    .form-actions button.primary {
+      background: #4ecdc4;
+      color: #0a0a0a;
+    }
+
+    .form-actions button:not(.primary) {
+      background: #333;
+      color: #aaa;
+    }
+
+    /* 模块卡片按钮 */
+    .module-actions {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 0.5rem;
+    }
+
+    .module-actions button {
+      padding: 0.25rem 0.5rem;
+      font-size: 0.75rem;
+      background: #16213e;
+      border: 1px solid #333;
+      border-radius: 4px;
+      color: #888;
+      cursor: pointer;
+    }
+
+    .module-actions button:hover {
+      border-color: #4ecdc4;
+      color: #4ecdc4;
+    }
+
+    /* 状态徽章 */
+    .status-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 12px;
+      font-size: 0.7rem;
+      margin-left: 0.5rem;
+    }
+
+    .status-badge.implemented { background: #1b4332; color: #2d6a4f; }
+    .status-badge.planned { background: #343a40; color: #adb5bd; }
+    .status-badge.inprogress { background: #3d405b; color: #81b29a; }
+    .status-badge.needsrefactor { background: #5f0f40; color: #e94560; }
+    .status-badge.deprecated { background: #3d3d3d; color: #888; }
+
+    /* 添加按钮 */
+    .add-planned-btn {
+      display: block;
+      width: 100%;
+      padding: 0.75rem;
+      margin-top: 1rem;
+      background: #16213e;
+      border: 2px dashed #333;
+      border-radius: 4px;
+      color: #888;
+      cursor: pointer;
+      text-align: center;
+    }
+
+    .add-planned-btn:hover {
+      border-color: #4ecdc4;
+      color: #4ecdc4;
+    }
+
+    /* Toast 通知 */
+    .toast {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      padding: 1rem 1.5rem;
+      background: #1a1a2e;
+      border: 1px solid #4ecdc4;
+      border-radius: 4px;
+      color: #4ecdc4;
+      z-index: 1001;
+      animation: slideIn 0.3s ease;
+    }
+
+    @keyframes slideIn {
+      from { transform: translateX(100%); opacity: 0; }
+      to { transform: translateX(0); opacity: 1; }
+    }

--- a/src/map/types-chunked.ts
+++ b/src/map/types-chunked.ts
@@ -129,6 +129,15 @@ export interface ChunkData {
 
   /** Chunk 元数据（可选） */
   metadata?: ChunkMetadata;
+
+  /** 计划中的模块（可选，用于设计驱动开发） */
+  plannedModules?: PlannedModule[];
+
+  /** 重构任务（可选，用于设计驱动开发） */
+  refactoringTasks?: RefactoringTask[];
+
+  /** 模块设计元数据（可选，moduleId -> ModuleDesignMeta） */
+  moduleDesignMeta?: Record<string, ModuleDesignMeta>;
 }
 
 export interface ChunkReferences {
@@ -169,4 +178,134 @@ export interface ChunkedGenerateOptions {
 
   /** 进度回调 */
   onProgress?: (message: string) => void;
+}
+
+// ============================================================================
+// 设计驱动开发类型定义
+// ============================================================================
+
+// ============================================================================
+// 模块状态枚举
+// ============================================================================
+
+/** 模块实现状态 */
+export type ModuleStatus =
+  | 'implemented'     // 已实现
+  | 'planned'         // 计划中
+  | 'in-progress'     // 开发中
+  | 'deprecated'      // 已废弃
+  | 'needs-refactor'; // 需要重构
+
+// ============================================================================
+// 计划模块
+// ============================================================================
+
+/** 计划中的模块 */
+export interface PlannedModule {
+  /** 模块 ID（预期路径） */
+  id: string;
+
+  /** 模块名称 */
+  name: string;
+
+  /** 设计状态 */
+  status: 'planned' | 'in-progress';
+
+  /** 设计备注 */
+  designNotes: string;
+
+  /** 优先级 */
+  priority: 'high' | 'medium' | 'low';
+
+  /** 预计代码行数 */
+  estimatedLines?: number;
+
+  /** 依赖的模块列表 */
+  dependencies: string[];
+
+  /** 预期导出的符号 */
+  expectedExports?: string[];
+
+  /** 创建时间 */
+  createdAt: string;
+
+  /** 更新时间 */
+  updatedAt?: string;
+}
+
+// ============================================================================
+// 重构任务
+// ============================================================================
+
+/** 重构任务类型 */
+export type RefactoringType =
+  | 'extract-function'   // 提取函数
+  | 'extract-class'      // 提取类
+  | 'rename'             // 重命名
+  | 'move'               // 移动模块
+  | 'split'              // 拆分模块
+  | 'merge'              // 合并模块
+  | 'inline'             // 内联
+  | 'other';             // 其他
+
+/** 重构任务 */
+export interface RefactoringTask {
+  /** 任务 ID */
+  id: string;
+
+  /** 目标模块 */
+  target: string;
+
+  /** 重构类型 */
+  type: RefactoringType;
+
+  /** 描述 */
+  description: string;
+
+  /** 重构原因 */
+  reason: string;
+
+  /** 任务状态 */
+  status: 'pending' | 'in-progress' | 'completed' | 'cancelled';
+
+  /** 优先级 */
+  priority: 'high' | 'medium' | 'low';
+
+  /** 创建时间 */
+  createdAt: string;
+
+  /** 完成时间 */
+  completedAt?: string;
+}
+
+// ============================================================================
+// 模块设计元数据
+// ============================================================================
+
+/** 模块设计元数据 */
+export interface ModuleDesignMeta {
+  /** 实现状态 */
+  status?: ModuleStatus;
+
+  /** 设计备注 */
+  designNotes?: string;
+
+  /** 标记时间 */
+  markedAt?: string;
+}
+
+// ============================================================================
+// 扩展的 ChunkData（明确包含设计相关字段）
+// ============================================================================
+
+/** 扩展后的 ChunkData（支持计划模块和重构任务） */
+export interface ChunkDataWithDesign extends ChunkData {
+  /** 计划中的模块 */
+  plannedModules: PlannedModule[];
+
+  /** 重构任务 */
+  refactoringTasks: RefactoringTask[];
+
+  /** 模块设计元数据（moduleId -> ModuleDesignMeta） */
+  moduleDesignMeta: Record<string, ModuleDesignMeta>;
 }


### PR DESCRIPTION
新增设计驱动开发功能，支持在蓝图中规划模块并生成代码骨架：

### 类型定义扩展 (types-chunked.ts)
- 添加 ModuleStatus 枚举（5种状态）
- 添加 PlannedModule 计划模块接口
- 添加 RefactoringTask 重构任务接口
- 添加 ModuleDesignMeta 设计元数据接口

### 后端 API (api.ts)
- POST /api/module/planned - 添加计划模块
- PUT /api/module-design - 更新模块设计
- POST /api/refactoring-task - 添加重构任务
- PUT /api/module-status - 更新模块状态
- DELETE /api/refactoring-task - 完成重构任务
@claude  更新claude.md文件
### 前端编辑界面
- 添加3个模态对话框（计划模块/重构任务/设计编辑）
- 实现9个编辑功能函数
- 添加5种状态徽章样式
- 模块卡片增加编辑和重构按钮
- Toast 通知反馈

### 命令行 (map.ts)
- 新增 /map implement 子命令
- 支持 --id 和 --all 选项
- 自动生成 TypeScript 代码骨架
- 自动更新蓝图中的模块状态

🤖 Generated with [Claude Code](https://claude.ai/code)