### PR TITLE
Add Task v2 system with dependency tracking (2.1.16)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "claude-web": "dist/web-cli.js"
       },
       "devDependencies": {
-        "@anthropic-ai/claude-code": "^2.1.14",
+        "@anthropic-ai/claude-code": "^2.1.19",
         "@types/chokidar": "^1.7.5",
         "@types/eventsource": "^1.1.15",
         "@types/express": "^5.0.6",
@@ -96,9 +96,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "2.1.14",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.14.tgz",
-      "integrity": "sha512-GLqbVO97N/qFuCf3MtWNQvaONfwSsYJj8iETXAI/hQV0LSg6exwjV0v12YiaHc53tUG7m4NeDbxIFXJk8gMQag==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.19.tgz",
+      "integrity": "sha512-/bUlQuX/6nKr1Zqfi/9Q6xf7WonUBk72ZfKKENU4WVrIFWqTv/0JJsoW/dHol9QBNHvyfKIeBbYu4avHNRAnuQ==",
       "dev": true,
       "license": "SEE LICENSE IN README.md",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-open",
-  "version": "2.1.14",
+  "version": "2.1.16",
   "description": "Open source Claude Code CLI - Educational Purpose Only",
   "type": "module",
   "bin": {
@@ -85,7 +85,7 @@
     "zod": "^3.22.0"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-code": "^2.1.14",
+    "@anthropic-ai/claude-code": "^2.1.19",
     "@types/chokidar": "^1.7.5",
     "@types/eventsource": "^1.1.15",
     "@types/express": "^5.0.6",

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -18,6 +18,8 @@ export * from './sandbox.js';
 export * from './skill.js';
 export * from './lsp.js';
 export * from './blueprint.js';
+export * from './task-storage.js';
+export * from './task-v2.js';
 
 import { toolRegistry } from './base.js';
 import { BashTool, KillShellTool } from './bash.js';
@@ -27,6 +29,8 @@ import { WebFetchTool } from './web.js';
 // WebSearchTool 已移除 - 使用 Anthropic API Server Tool (web_search_20250305) 替代
 import { TodoWriteTool } from './todo.js';
 import { TaskTool, TaskOutputTool } from './agent.js';
+import { TaskCreateTool, TaskGetTool, TaskUpdateTool, TaskListTool } from './task-v2.js';
+import { isTasksEnabled } from './task-storage.js';
 import { NotebookEditTool } from './notebook.js';
 import { EnterPlanModeTool, ExitPlanModeTool } from './planmode.js';
 import { MCPSearchTool, ListMcpResourcesTool, ReadMcpResourceTool } from './mcp.js';
@@ -57,10 +61,18 @@ export function registerAllTools(): void {
   // WebSearch: 使用 Anthropic API Server Tool (web_search_20250305)
   // 在 client.ts 的 buildApiTools 中自动添加，无需注册客户端工具
 
-  // 5. 任务管理 (3个)
+  // 5. 任务管理 (3个 + Task v2 工具 4个)
   toolRegistry.register(new TodoWriteTool());
   toolRegistry.register(new TaskTool());
   toolRegistry.register(new TaskOutputTool());
+
+  // Task v2 系统 (2.1.16 新增，支持依赖追踪)
+  if (isTasksEnabled()) {
+    toolRegistry.register(new TaskCreateTool());
+    toolRegistry.register(new TaskGetTool());
+    toolRegistry.register(new TaskUpdateTool());
+    toolRegistry.register(new TaskListTool());
+  }
 
   // 6. Notebook 编辑 (1个)
   toolRegistry.register(new NotebookEditTool());

--- a/src/tools/task-storage.ts
+++ b/src/tools/task-storage.ts
@@ -1,0 +1,402 @@
+/**
+ * Task v2 存储系统
+ * 官方 2.1.16 新增的任务管理系统，支持依赖追踪
+ *
+ * 基于官方实现：
+ * - 每个任务存储为独立 JSON 文件
+ * - 存储路径：~/.claude/tasks/{listId}/{taskId}.json
+ * - 支持依赖追踪：blocks / blockedBy
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+// ============================================================================
+// 类型定义
+// ============================================================================
+
+/**
+ * Task v2 状态
+ */
+export type TaskStatus = 'pending' | 'in_progress' | 'completed';
+
+/**
+ * Task v2 数据结构（官方 Sm3 schema）
+ */
+export interface TaskV2 {
+  /** 唯一标识符 */
+  id: string;
+  /** 任务简短标题 */
+  subject: string;
+  /** 详细描述 */
+  description: string;
+  /** 进行中时显示的文本（可选） */
+  activeForm?: string;
+  /** 所有者（多代理场景，可选） */
+  owner?: string;
+  /** 任务状态 */
+  status: TaskStatus;
+  /** 该任务阻塞的任务 ID 列表 */
+  blocks: string[];
+  /** 阻塞该任务的任务 ID 列表 */
+  blockedBy: string[];
+  /** 任意元数据（可选） */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * TaskCreate 输入
+ */
+export interface TaskCreateInput {
+  subject: string;
+  description: string;
+  activeForm?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * TaskCreate 输出
+ */
+export interface TaskCreateOutput {
+  task: {
+    id: string;
+    subject: string;
+  };
+}
+
+/**
+ * TaskGet 输入
+ */
+export interface TaskGetInput {
+  taskId: string;
+}
+
+/**
+ * TaskGet 输出
+ */
+export interface TaskGetOutput {
+  task: {
+    id: string;
+    subject: string;
+    description: string;
+    status: TaskStatus;
+    blocks: string[];
+    blockedBy: string[];
+  } | null;
+}
+
+/**
+ * TaskUpdate 输入
+ */
+export interface TaskUpdateInput {
+  taskId: string;
+  subject?: string;
+  description?: string;
+  activeForm?: string;
+  status?: TaskStatus;
+  addBlocks?: string[];
+  addBlockedBy?: string[];
+  owner?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * TaskUpdate 输出
+ */
+export interface TaskUpdateOutput {
+  success: boolean;
+  taskId: string;
+  updatedFields: string[];
+  error?: string;
+  statusChange?: {
+    from: string;
+    to: string;
+  };
+}
+
+/**
+ * TaskList 输出
+ */
+export interface TaskListOutput {
+  tasks: Array<{
+    id: string;
+    subject: string;
+    status: TaskStatus;
+    owner?: string;
+    blockedBy: string[];
+  }>;
+}
+
+// ============================================================================
+// 存储实现
+// ============================================================================
+
+// 缓存已创建的目录
+const createdDirs = new Set<string>();
+
+// 任务 ID 计数器缓存
+const idCounters = new Map<string, number>();
+
+/**
+ * 获取任务存储根目录
+ */
+function getTasksDir(): string {
+  return join(homedir(), '.claude', 'tasks');
+}
+
+/**
+ * 规范化列表 ID（移除非法字符）
+ */
+function normalizeListId(listId: string): string {
+  return listId.replace(/[^a-zA-Z0-9_-]/g, '-');
+}
+
+/**
+ * 获取指定列表的存储目录
+ */
+function getListDir(listId: string): string {
+  return join(getTasksDir(), normalizeListId(listId));
+}
+
+/**
+ * 获取任务文件路径
+ */
+function getTaskFile(listId: string, taskId: string): string {
+  return join(getListDir(listId), `${normalizeListId(taskId)}.json`);
+}
+
+/**
+ * 确保目录存在
+ */
+function ensureDir(listId: string): void {
+  const dir = getListDir(listId);
+  if (!createdDirs.has(dir)) {
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    createdDirs.add(dir);
+  }
+}
+
+/**
+ * 获取下一个任务 ID（递增整数）
+ */
+function getNextTaskId(listId: string): string {
+  const dir = getListDir(listId);
+
+  // 检查缓存
+  if (!idCounters.has(listId)) {
+    let maxId = 0;
+
+    if (existsSync(dir)) {
+      const files = readdirSync(dir);
+      for (const file of files) {
+        if (!file.endsWith('.json')) continue;
+        const id = parseInt(file.replace('.json', ''), 10);
+        if (!isNaN(id) && id > maxId) {
+          maxId = id;
+        }
+      }
+    }
+
+    idCounters.set(listId, maxId);
+  }
+
+  const nextId = (idCounters.get(listId) || 0) + 1;
+  idCounters.set(listId, nextId);
+
+  return String(nextId);
+}
+
+/**
+ * 验证任务数据
+ */
+function validateTask(data: unknown): TaskV2 | null {
+  if (!data || typeof data !== 'object') return null;
+
+  const task = data as Record<string, unknown>;
+
+  // 验证必需字段
+  if (typeof task.id !== 'string') return null;
+  if (typeof task.subject !== 'string') return null;
+  if (typeof task.description !== 'string') return null;
+  if (!['pending', 'in_progress', 'completed'].includes(task.status as string)) return null;
+  if (!Array.isArray(task.blocks)) return null;
+  if (!Array.isArray(task.blockedBy)) return null;
+
+  return {
+    id: task.id,
+    subject: task.subject,
+    description: task.description,
+    activeForm: typeof task.activeForm === 'string' ? task.activeForm : undefined,
+    owner: typeof task.owner === 'string' ? task.owner : undefined,
+    status: task.status as TaskStatus,
+    blocks: task.blocks as string[],
+    blockedBy: task.blockedBy as string[],
+    metadata: typeof task.metadata === 'object' ? task.metadata as Record<string, unknown> : undefined,
+  };
+}
+
+// ============================================================================
+// 核心函数（对应官方实现）
+// ============================================================================
+
+/**
+ * 获取当前的任务列表 ID
+ * 官方 tj() 函数
+ */
+export function getCurrentListId(): string {
+  // 优先使用环境变量
+  if (process.env.CLAUDE_CODE_TASK_LIST_ID) {
+    return process.env.CLAUDE_CODE_TASK_LIST_ID;
+  }
+  // 使用默认列表 ID
+  return 'default';
+}
+
+/**
+ * 创建新任务
+ * 官方 W71() 函数
+ */
+export function createTask(listId: string, taskData: Omit<TaskV2, 'id'>): string {
+  ensureDir(listId);
+
+  const id = getNextTaskId(listId);
+  const task: TaskV2 = {
+    id,
+    ...taskData,
+  };
+
+  const file = getTaskFile(listId, id);
+  writeFileSync(file, JSON.stringify(task, null, 2));
+
+  return id;
+}
+
+/**
+ * 获取单个任务
+ * 官方 An() 函数
+ */
+export function getTask(listId: string, taskId: string): TaskV2 | null {
+  const file = getTaskFile(listId, taskId);
+
+  if (!existsSync(file)) {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(file, 'utf-8');
+    const data = JSON.parse(content);
+    return validateTask(data);
+  } catch (err) {
+    console.error(`[Tasks] Failed to read task ${taskId}:`, err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}
+
+/**
+ * 更新任务
+ * 官方 S0A() 函数
+ */
+export function updateTask(listId: string, taskId: string, updates: Partial<Omit<TaskV2, 'id'>>): TaskV2 | null {
+  const task = getTask(listId, taskId);
+  if (!task) return null;
+
+  const updatedTask: TaskV2 = {
+    ...task,
+    ...updates,
+  };
+
+  const file = getTaskFile(listId, taskId);
+  writeFileSync(file, JSON.stringify(updatedTask, null, 2));
+
+  return updatedTask;
+}
+
+/**
+ * 获取所有任务
+ * 官方 $T() 函数
+ */
+export function getAllTasks(listId: string): TaskV2[] {
+  const dir = getListDir(listId);
+
+  if (!existsSync(dir)) {
+    return [];
+  }
+
+  const files = readdirSync(dir);
+  const tasks: TaskV2[] = [];
+
+  for (const file of files) {
+    if (!file.endsWith('.json')) continue;
+
+    const taskId = file.replace('.json', '');
+    const task = getTask(listId, taskId);
+    if (task) {
+      tasks.push(task);
+    }
+  }
+
+  return tasks;
+}
+
+/**
+ * 添加依赖关系
+ * 官方 r16() 函数
+ *
+ * @param listId 列表 ID
+ * @param blockerId 阻塞者任务 ID（该任务阻塞其他任务）
+ * @param blockedId 被阻塞任务 ID（该任务被阻塞）
+ * @returns 是否成功
+ */
+export function addDependency(listId: string, blockerId: string, blockedId: string): boolean {
+  const blocker = getTask(listId, blockerId);
+  const blocked = getTask(listId, blockedId);
+
+  if (!blocker || !blocked) {
+    return false;
+  }
+
+  // 更新阻塞者的 blocks 列表
+  if (!blocker.blocks.includes(blockedId)) {
+    updateTask(listId, blockerId, {
+      blocks: [...blocker.blocks, blockedId],
+    });
+  }
+
+  // 更新被阻塞者的 blockedBy 列表
+  if (!blocked.blockedBy.includes(blockerId)) {
+    updateTask(listId, blockedId, {
+      blockedBy: [...blocked.blockedBy, blockerId],
+    });
+  }
+
+  return true;
+}
+
+/**
+ * 检查是否启用了 Task v2 系统
+ * 官方 ew() 函数
+ */
+export function isTasksEnabled(): boolean {
+  const envValue = process.env.CLAUDE_CODE_ENABLE_TASKS;
+
+  // 显式禁用
+  if (envValue === '0' || envValue === 'false') {
+    return false;
+  }
+
+  // 显式启用
+  if (envValue === '1' || envValue === 'true') {
+    return true;
+  }
+
+  // 默认启用（与官方 2.1.16+ 保持一致）
+  return true;
+}
+
+/**
+ * 有效的状态列表
+ */
+export const VALID_STATUSES: TaskStatus[] = ['pending', 'in_progress', 'completed'];

--- a/src/tools/task-v2.ts
+++ b/src/tools/task-v2.ts
@@ -1,0 +1,544 @@
+/**
+ * Task v2 工具
+ * 官方 2.1.16 新增的任务管理系统
+ *
+ * 包含 4 个工具：
+ * - TaskCreate: 创建新任务
+ * - TaskGet: 获取单个任务
+ * - TaskUpdate: 更新任务（支持依赖追踪）
+ * - TaskList: 列出所有任务
+ */
+
+import { BaseTool } from './base.js';
+import type { ToolResult, ToolDefinition } from '../types/index.js';
+import {
+  createTask,
+  getTask,
+  updateTask,
+  getAllTasks,
+  addDependency,
+  getCurrentListId,
+  isTasksEnabled,
+  VALID_STATUSES,
+  type TaskCreateInput,
+  type TaskCreateOutput,
+  type TaskGetInput,
+  type TaskGetOutput,
+  type TaskUpdateInput,
+  type TaskUpdateOutput,
+  type TaskListOutput,
+  type TaskStatus,
+} from './task-storage.js';
+
+// ============================================================================
+// TaskCreate 工具
+// ============================================================================
+
+const TASK_CREATE_DESCRIPTION = `Creates a new task in the task management system.
+
+Use this tool to:
+- Create tasks for tracking complex multi-step work
+- Break down large features into manageable pieces
+- Track dependencies between tasks
+
+Each task has:
+- subject: A brief title (required)
+- description: Detailed description of what needs to be done (required)
+- activeForm: Text shown in spinner when in_progress (optional)
+- metadata: Arbitrary key-value data (optional)
+
+New tasks start with status "pending" and empty dependency lists.`;
+
+const TASK_CREATE_PROMPT = `When you have a complex task that needs to be broken into smaller pieces, use TaskCreate to create individual tasks. After creating tasks, use TaskUpdate to:
+- Change status as you work (pending → in_progress → completed)
+- Add dependencies with addBlocks/addBlockedBy
+
+Example workflow:
+1. TaskCreate: "Set up database schema"
+2. TaskCreate: "Implement API endpoints"
+3. TaskCreate: "Write frontend components"
+4. TaskUpdate task 2 with addBlockedBy=[task 1 id] (API depends on schema)
+5. TaskUpdate task 3 with addBlockedBy=[task 2 id] (frontend depends on API)`;
+
+export class TaskCreateTool extends BaseTool<TaskCreateInput, ToolResult> {
+  name = 'TaskCreate';
+  description = TASK_CREATE_DESCRIPTION;
+
+  getInputSchema(): ToolDefinition['inputSchema'] {
+    return {
+      type: 'object',
+      properties: {
+        subject: {
+          type: 'string',
+          description: 'A brief title for the task',
+        },
+        description: {
+          type: 'string',
+          description: 'A detailed description of what needs to be done',
+        },
+        activeForm: {
+          type: 'string',
+          description: 'Present continuous form shown in spinner when in_progress (e.g., "Running tests")',
+        },
+        metadata: {
+          type: 'object',
+          additionalProperties: true,
+          description: 'Arbitrary metadata to attach to the task',
+        },
+      },
+      required: ['subject', 'description'],
+    };
+  }
+
+  async execute(input: TaskCreateInput): Promise<ToolResult> {
+    if (!isTasksEnabled()) {
+      return {
+        success: false,
+        error: 'Task management system is disabled. Set CLAUDE_CODE_ENABLE_TASKS=true to enable.',
+      };
+    }
+
+    const listId = getCurrentListId();
+
+    const taskId = createTask(listId, {
+      subject: input.subject,
+      description: input.description,
+      activeForm: input.activeForm,
+      status: 'pending',
+      owner: undefined,
+      blocks: [],
+      blockedBy: [],
+      metadata: input.metadata,
+    });
+
+    const result: TaskCreateOutput = {
+      task: {
+        id: taskId,
+        subject: input.subject,
+      },
+    };
+
+    return {
+      success: true,
+      output: `Created task #${taskId}: ${input.subject}`,
+      data: result,
+    };
+  }
+}
+
+// ============================================================================
+// TaskGet 工具
+// ============================================================================
+
+const TASK_GET_DESCRIPTION = `Retrieves details of a specific task by its ID.
+
+Returns:
+- id: Task identifier
+- subject: Brief title
+- description: Detailed description
+- status: Current status (pending/in_progress/completed)
+- blocks: IDs of tasks this task blocks
+- blockedBy: IDs of tasks blocking this task
+
+Returns null if task not found.`;
+
+const TASK_GET_PROMPT = `Use TaskGet when you need to:
+- Check the current status of a specific task
+- See what dependencies a task has
+- Review the task description before starting work`;
+
+export class TaskGetTool extends BaseTool<TaskGetInput, ToolResult> {
+  name = 'TaskGet';
+  description = TASK_GET_DESCRIPTION;
+
+  getInputSchema(): ToolDefinition['inputSchema'] {
+    return {
+      type: 'object',
+      properties: {
+        taskId: {
+          type: 'string',
+          description: 'The ID of the task to retrieve',
+        },
+      },
+      required: ['taskId'],
+    };
+  }
+
+  async execute(input: TaskGetInput): Promise<ToolResult> {
+    if (!isTasksEnabled()) {
+      return {
+        success: false,
+        error: 'Task management system is disabled. Set CLAUDE_CODE_ENABLE_TASKS=true to enable.',
+      };
+    }
+
+    const listId = getCurrentListId();
+    const task = getTask(listId, input.taskId);
+
+    if (!task) {
+      const result: TaskGetOutput = { task: null };
+      return {
+        success: false,
+        error: 'Task not found',
+        data: result,
+      };
+    }
+
+    const result: TaskGetOutput = {
+      task: {
+        id: task.id,
+        subject: task.subject,
+        description: task.description,
+        status: task.status,
+        blocks: task.blocks,
+        blockedBy: task.blockedBy,
+      },
+    };
+
+    // 格式化输出
+    const lines = [
+      `Task #${task.id}: ${task.subject}`,
+      `Status: ${task.status}`,
+      `Description: ${task.description}`,
+    ];
+
+    if (task.blockedBy.length > 0) {
+      lines.push(`Blocked by: ${task.blockedBy.map(id => `#${id}`).join(', ')}`);
+    }
+    if (task.blocks.length > 0) {
+      lines.push(`Blocks: ${task.blocks.map(id => `#${id}`).join(', ')}`);
+    }
+
+    return {
+      success: true,
+      output: lines.join('\n'),
+      data: result,
+    };
+  }
+}
+
+// ============================================================================
+// TaskUpdate 工具
+// ============================================================================
+
+const TASK_UPDATE_DESCRIPTION = `Updates an existing task's properties.
+
+Can update:
+- subject: New title
+- description: New description
+- activeForm: New spinner text
+- status: New status (pending/in_progress/completed)
+- addBlocks: Task IDs that this task blocks (dependency tracking)
+- addBlockedBy: Task IDs that block this task (dependency tracking)
+- owner: Assign task to an owner (for multi-agent scenarios)
+- metadata: Merge new metadata (set key to null to delete)
+
+Dependency tracking:
+- addBlocks: "This task must complete before tasks X, Y, Z can start"
+- addBlockedBy: "This task cannot start until tasks A, B, C complete"`;
+
+const TASK_UPDATE_PROMPT = `Use TaskUpdate to:
+
+1. Change task status as you work:
+   - Start work: status="in_progress"
+   - Finish work: status="completed"
+
+2. Add dependencies:
+   - TaskUpdate taskId="2" addBlockedBy=["1"] → Task 2 waits for task 1
+   - TaskUpdate taskId="1" addBlocks=["2", "3"] → Task 1 blocks tasks 2 and 3
+
+3. Update task details:
+   - Refine description as you learn more
+   - Update activeForm for better progress display`;
+
+export class TaskUpdateTool extends BaseTool<TaskUpdateInput, ToolResult> {
+  name = 'TaskUpdate';
+  description = TASK_UPDATE_DESCRIPTION;
+
+  getInputSchema(): ToolDefinition['inputSchema'] {
+    return {
+      type: 'object',
+      properties: {
+        taskId: {
+          type: 'string',
+          description: 'The ID of the task to update',
+        },
+        subject: {
+          type: 'string',
+          description: 'New subject for the task',
+        },
+        description: {
+          type: 'string',
+          description: 'New description for the task',
+        },
+        activeForm: {
+          type: 'string',
+          description: 'Present continuous form shown in spinner when in_progress (e.g., "Running tests")',
+        },
+        status: {
+          type: 'string',
+          enum: ['pending', 'in_progress', 'completed'],
+          description: 'New status for the task',
+        },
+        addBlocks: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Task IDs that this task blocks',
+        },
+        addBlockedBy: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Task IDs that block this task',
+        },
+        owner: {
+          type: 'string',
+          description: 'New owner for the task',
+        },
+        metadata: {
+          type: 'object',
+          additionalProperties: true,
+          description: 'Metadata keys to merge into the task. Set a key to null to delete it.',
+        },
+      },
+      required: ['taskId'],
+    };
+  }
+
+  async execute(input: TaskUpdateInput): Promise<ToolResult> {
+    if (!isTasksEnabled()) {
+      return {
+        success: false,
+        error: 'Task management system is disabled. Set CLAUDE_CODE_ENABLE_TASKS=true to enable.',
+      };
+    }
+
+    const listId = getCurrentListId();
+    const task = getTask(listId, input.taskId);
+
+    if (!task) {
+      const result: TaskUpdateOutput = {
+        success: false,
+        taskId: input.taskId,
+        updatedFields: [],
+        error: 'Task not found',
+      };
+      return {
+        success: false,
+        error: 'Task not found',
+        data: result,
+      };
+    }
+
+    const updatedFields: string[] = [];
+    const updates: Partial<typeof task> = {};
+
+    // 更新简单字段
+    if (input.subject !== undefined && input.subject !== task.subject) {
+      updates.subject = input.subject;
+      updatedFields.push('subject');
+    }
+
+    if (input.description !== undefined && input.description !== task.description) {
+      updates.description = input.description;
+      updatedFields.push('description');
+    }
+
+    if (input.activeForm !== undefined && input.activeForm !== task.activeForm) {
+      updates.activeForm = input.activeForm;
+      updatedFields.push('activeForm');
+    }
+
+    if (input.owner !== undefined && input.owner !== task.owner) {
+      updates.owner = input.owner;
+      updatedFields.push('owner');
+    }
+
+    // 更新元数据
+    if (input.metadata !== undefined) {
+      const newMetadata = { ...(task.metadata ?? {}) };
+      for (const [key, value] of Object.entries(input.metadata)) {
+        if (value === null) {
+          delete newMetadata[key];
+        } else {
+          newMetadata[key] = value;
+        }
+      }
+      updates.metadata = newMetadata;
+      updatedFields.push('metadata');
+    }
+
+    // 更新状态
+    let statusChange: { from: string; to: string } | undefined;
+    if (input.status !== undefined && input.status !== task.status) {
+      if (!VALID_STATUSES.includes(input.status as TaskStatus)) {
+        const result: TaskUpdateOutput = {
+          success: false,
+          taskId: input.taskId,
+          updatedFields: [],
+          error: `Invalid status "${input.status}". Valid statuses: ${VALID_STATUSES.join(', ')}`,
+        };
+        return {
+          success: false,
+          error: result.error,
+          data: result,
+        };
+      }
+      statusChange = { from: task.status, to: input.status };
+      updates.status = input.status as TaskStatus;
+      updatedFields.push('status');
+    }
+
+    // 应用简单更新
+    if (Object.keys(updates).length > 0) {
+      updateTask(listId, input.taskId, updates);
+    }
+
+    // 处理依赖关系：addBlocks
+    if (input.addBlocks && input.addBlocks.length > 0) {
+      const newBlocks = input.addBlocks.filter(id => !task.blocks.includes(id));
+      for (const blockedId of newBlocks) {
+        addDependency(listId, input.taskId, blockedId);
+      }
+      if (newBlocks.length > 0) {
+        updatedFields.push('blocks');
+      }
+    }
+
+    // 处理依赖关系：addBlockedBy
+    if (input.addBlockedBy && input.addBlockedBy.length > 0) {
+      const newBlockedBy = input.addBlockedBy.filter(id => !task.blockedBy.includes(id));
+      for (const blockerId of newBlockedBy) {
+        addDependency(listId, blockerId, input.taskId);
+      }
+      if (newBlockedBy.length > 0) {
+        updatedFields.push('blockedBy');
+      }
+    }
+
+    const result: TaskUpdateOutput = {
+      success: true,
+      taskId: input.taskId,
+      updatedFields,
+      statusChange,
+    };
+
+    // 格式化输出
+    let output = `Updated task #${input.taskId}`;
+    if (updatedFields.length > 0) {
+      output += `: ${updatedFields.join(', ')}`;
+    }
+    if (statusChange) {
+      output += ` (${statusChange.from} → ${statusChange.to})`;
+    }
+
+    return {
+      success: true,
+      output,
+      data: result,
+    };
+  }
+}
+
+// ============================================================================
+// TaskList 工具
+// ============================================================================
+
+const TASK_LIST_DESCRIPTION = `Lists all tasks in the current task list.
+
+Returns for each task:
+- id: Task identifier
+- subject: Brief title
+- status: Current status (pending/in_progress/completed)
+- owner: Assigned owner (if any)
+- blockedBy: IDs of tasks blocking this task
+
+Completed tasks are included but typically filtered when displaying to users.`;
+
+const TASK_LIST_PROMPT = `Use TaskList to:
+- Get an overview of all tasks
+- Find tasks that are blocked or blocking others
+- Check which tasks are in progress vs pending
+
+After TaskList, use TaskGet for detailed information on specific tasks.`;
+
+export class TaskListTool extends BaseTool<Record<string, never>, ToolResult> {
+  name = 'TaskList';
+  description = TASK_LIST_DESCRIPTION;
+
+  getInputSchema(): ToolDefinition['inputSchema'] {
+    return {
+      type: 'object',
+      properties: {},
+      required: [],
+    };
+  }
+
+  async execute(): Promise<ToolResult> {
+    if (!isTasksEnabled()) {
+      return {
+        success: false,
+        error: 'Task management system is disabled. Set CLAUDE_CODE_ENABLE_TASKS=true to enable.',
+      };
+    }
+
+    const listId = getCurrentListId();
+    const allTasks = getAllTasks(listId);
+
+    // 按 ID 排序
+    allTasks.sort((a, b) => parseInt(a.id, 10) - parseInt(b.id, 10));
+
+    // 过滤已完成任务的 ID 集合（用于显示依赖关系）
+    const completedIds = new Set(
+      allTasks.filter(t => t.status === 'completed').map(t => t.id)
+    );
+
+    const result: TaskListOutput = {
+      tasks: allTasks.map(task => ({
+        id: task.id,
+        subject: task.subject,
+        status: task.status,
+        owner: task.owner,
+        blockedBy: task.blockedBy,
+      })),
+    };
+
+    if (allTasks.length === 0) {
+      return {
+        success: true,
+        output: 'No tasks found.',
+        data: result,
+      };
+    }
+
+    // 格式化输出
+    const lines = ['Tasks:'];
+    for (const task of allTasks) {
+      let line = `  #${task.id} [${task.status}] ${task.subject}`;
+
+      // 显示未完成的阻塞关系
+      const activeBlockers = task.blockedBy.filter(id => !completedIds.has(id));
+      if (activeBlockers.length > 0) {
+        line += ` (blocked by: ${activeBlockers.map(id => `#${id}`).join(', ')})`;
+      }
+
+      if (task.owner) {
+        line += ` [owner: ${task.owner}]`;
+      }
+
+      lines.push(line);
+    }
+
+    // 统计信息
+    const pending = allTasks.filter(t => t.status === 'pending').length;
+    const inProgress = allTasks.filter(t => t.status === 'in_progress').length;
+    const completed = allTasks.filter(t => t.status === 'completed').length;
+    lines.push('');
+    lines.push(`Summary: ${pending} pending, ${inProgress} in_progress, ${completed} completed`);
+
+    return {
+      success: true,
+      output: lines.join('\n'),
+      data: result,
+    };
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -148,10 +148,20 @@ export type {
   // WebSearchInput 已移除 - 使用 Server Tool (web_search_20250305)
 } from './tools.js';
 
-// --- Todo 工具 ---
+// --- Todo 工具 (v1 Legacy) ---
 export type {
   TodoItem,
   TodoWriteInput as TodoWriteToolInput,
+} from './tools.js';
+
+// --- Task v2 工具 (2.1.16+) ---
+export type {
+  TaskV2Status,
+  TaskV2Item,
+  TaskCreateInput as TaskCreateToolInput,
+  TaskGetInput as TaskGetToolInput,
+  TaskUpdateInput as TaskUpdateToolInput,
+  TaskListInput as TaskListToolInput,
 } from './tools.js';
 
 // --- Notebook 工具 ---

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -380,11 +380,11 @@ export interface WebFetchInput {
 // Server Tool 由 Anthropic 服务器执行，客户端不需要处理输入参数
 
 // ============================================================================
-// Todo Tool
+// Todo Tool (v1 - Legacy)
 // ============================================================================
 
 /**
- * A single todo item
+ * A single todo item (v1 - Legacy)
  */
 export interface TodoItem {
   /**
@@ -408,7 +408,7 @@ export interface TodoItem {
 }
 
 /**
- * Input parameters for the TodoWrite tool
+ * Input parameters for the TodoWrite tool (v1 - Legacy)
  *
  * Manages a structured task list for tracking progress.
  */
@@ -417,6 +417,94 @@ export interface TodoWriteInput {
    * The updated todo list
    */
   todos: TodoItem[];
+}
+
+// ============================================================================
+// Task v2 System (2.1.16+)
+// Supports dependency tracking with blocks/blockedBy
+// ============================================================================
+
+/**
+ * Task v2 status
+ */
+export type TaskV2Status = "pending" | "in_progress" | "completed";
+
+/**
+ * Task v2 data structure
+ * New task management system with dependency tracking
+ */
+export interface TaskV2Item {
+  /** Unique identifier */
+  id: string;
+  /** Brief task title */
+  subject: string;
+  /** Detailed description */
+  description: string;
+  /** Text shown in spinner when in_progress */
+  activeForm?: string;
+  /** Owner (for multi-agent scenarios) */
+  owner?: string;
+  /** Task status */
+  status: TaskV2Status;
+  /** IDs of tasks this task blocks */
+  blocks: string[];
+  /** IDs of tasks blocking this task */
+  blockedBy: string[];
+  /** Arbitrary metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Input for TaskCreate tool
+ */
+export interface TaskCreateInput {
+  /** Brief task title */
+  subject: string;
+  /** Detailed description */
+  description: string;
+  /** Text shown in spinner when in_progress */
+  activeForm?: string;
+  /** Arbitrary metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Input for TaskGet tool
+ */
+export interface TaskGetInput {
+  /** Task ID to retrieve */
+  taskId: string;
+}
+
+/**
+ * Input for TaskUpdate tool
+ */
+export interface TaskUpdateInput {
+  /** Task ID to update */
+  taskId: string;
+  /** New title */
+  subject?: string;
+  /** New description */
+  description?: string;
+  /** New spinner text */
+  activeForm?: string;
+  /** New status */
+  status?: TaskV2Status;
+  /** Task IDs that this task blocks */
+  addBlocks?: string[];
+  /** Task IDs that block this task */
+  addBlockedBy?: string[];
+  /** New owner */
+  owner?: string;
+  /** Metadata to merge (set key to null to delete) */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Input for TaskList tool (no parameters)
+ */
+export interface TaskListInput {
+  // No parameters required
 }
 
 // ============================================================================
@@ -760,6 +848,11 @@ export type ToolInputSchemas =
   | WebFetchInput
   // WebSearchInput 已移除 - 使用 Server Tool
   | TodoWriteInput
+  // Task v2 (2.1.16+)
+  | TaskCreateInput
+  | TaskGetInput
+  | TaskUpdateInput
+  | TaskListInput
   | NotebookEditInput
   | McpInput
   | ListMcpResourcesInput


### PR DESCRIPTION
## Summary
Implements the official Task v2 system introduced in version 2.1.16, adding a new task management system with dependency tracking capabilities. This complements the existing legacy Todo system with a more sophisticated task management approach.

## Key Changes

### New Files
- **`src/tools/task-storage.ts`**: Core storage implementation for Task v2
  - File-based storage at `~/.claude/tasks/{listId}/{taskId}.json`
  - Support for task dependencies via `blocks` and `blockedBy` arrays
  - Functions for CRUD operations: `createTask`, `getTask`, `updateTask`, `getAllTasks`
  - Dependency management via `addDependency` function
  - Feature flag support via `isTasksEnabled()` and `CLAUDE_CODE_ENABLE_TASKS` env var

- **`src/tools/task-v2.ts`**: Four new tool implementations
  - `TaskCreate`: Create new tasks with subject, description, and optional metadata
  - `TaskGet`: Retrieve task details including dependencies
  - `TaskUpdate`: Update task properties and manage dependencies
  - `TaskList`: List all tasks with status and dependency information

### Modified Files
- **`src/tools/index.ts`**: 
  - Export new task-storage and task-v2 modules
  - Register Task v2 tools conditionally when enabled
  - Maintain backward compatibility with existing Todo tools

- **`src/types/tools.ts`**: 
  - Add `TaskV2Status`, `TaskV2Item` type definitions
  - Add input types for all four Task v2 tools
  - Update `ToolInputSchemas` union to include new tool inputs
  - Mark legacy Todo types with comments for clarity

- **`src/types/index.ts`**: 
  - Export new Task v2 type definitions

- **`package.json` & `package-lock.json`**: 
  - Bump `@anthropic-ai/claude-code` from 2.1.14 to 2.1.19
  - Bump project version from 2.1.14 to 2.1.16

## Implementation Details

### Task Storage
- Tasks are stored as individual JSON files for simplicity and atomicity
- Task IDs are auto-incrementing integers per list
- Directory structure: `~/.claude/tasks/{listId}/{taskId}.json`
- Supports multiple task lists via `CLAUDE_CODE_TASK_LIST_ID` env var (defaults to "default")

### Dependency Tracking
- `blocks`: Array of task IDs that this task blocks (must complete before they can start)
- `blockedBy`: Array of task IDs that block this task (must complete before this can start)
- Bidirectional updates: Adding a dependency updates both tasks automatically

### Feature Flag
- Enabled by default (matching official 2.1.16+ behavior)
- Can be disabled via `CLAUDE_CODE_ENABLE_TASKS=false`
- Tools gracefully fail with helpful error message when disabled

### Backward Compatibility
- Legacy Todo system remains unchanged and functional
- Task v2 tools are registered conditionally
- No breaking changes to existing APIs