### PR TITLE
Add task interruption recovery feature for service restarts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-open",
-  "version": "2.1.16",
+  "version": "2.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-open",
-      "version": "2.1.16",
+      "version": "2.1.19",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.70.0",

--- a/src/web/client/src/api/blueprint.ts
+++ b/src/web/client/src/api/blueprint.ts
@@ -319,6 +319,23 @@ export const blueprintApi = {
   },
 
   /**
+   * 重置所有中断的任务
+   * 将 coding、testing、test_writing、review 状态的任务重置为 pending
+   * 用于服务重启后恢复被中断的任务
+   */
+  resetInterruptedTasks: async (
+    id: string,
+    resetRetryCount: boolean = false
+  ): Promise<{ resetCount: number; taskTreeId: string; message: string }> => {
+    const response = await fetch(`/api/blueprint/blueprints/${id}/reset-interrupted`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ resetRetryCount }),
+    });
+    return handleResponse(response);
+  },
+
+  /**
    * 删除蓝图
    */
   deleteBlueprint: async (id: string): Promise<void> => {

--- a/src/web/client/src/pages/SwarmConsole/index.tsx
+++ b/src/web/client/src/pages/SwarmConsole/index.tsx
@@ -522,6 +522,31 @@ export default function SwarmConsole({ initialBlueprintId }: SwarmConsoleProps) 
     }
   };
 
+  // 重置中断任务（服务重启后恢复）
+  const handleResetInterruptedTasks = async () => {
+    if (!selectedBlueprintId) {
+      alert('请先选择一个蓝图');
+      return;
+    }
+
+    const confirmed = window.confirm(
+      '确定要重置所有中断的任务吗？\n这将把所有"执行中"状态（coding、testing等）的任务重置为待执行，用于服务重启后恢复。'
+    );
+
+    if (!confirmed) return;
+
+    try {
+      const { blueprintApi } = await import('../../api/blueprint');
+      const result = await blueprintApi.resetInterruptedTasks(selectedBlueprintId);
+      alert(`成功重置 ${result.resetCount} 个中断任务`);
+      refresh();
+      fetchCoordinatorData();
+    } catch (err: any) {
+      console.error('重置中断任务失败:', err);
+      alert(`重置中断任务失败: ${err.message || '未知错误'}`);
+    }
+  };
+
   const handleBlueprintSelect = (blueprintId: string) => {
     setSelectedBlueprintId(blueprintId);
   };
@@ -656,6 +681,7 @@ export default function SwarmConsole({ initialBlueprintId }: SwarmConsoleProps) 
               <button className={styles.iconButton} title="恢复执行" onClick={handleResumeExecution}>▶️</button>
               <button className={styles.iconButton} title="停止执行" onClick={handleStopExecution}>⏹️</button>
               <button className={styles.iconButton} title="重置失败任务" onClick={handleResetFailedTasks}>🔁</button>
+              <button className={styles.iconButton} title="重置中断任务(重启恢复)" onClick={handleResetInterruptedTasks}>🔄</button>
             </div>
           </div>
           <div className={styles.panelContent}>


### PR DESCRIPTION
## Summary
This PR adds a new feature to recover tasks that were interrupted during service restarts. When a service restarts, tasks in execution states (coding, testing, test_writing, review) may be left hanging without active workers. This feature provides a way to reset those interrupted tasks back to pending status so they can be re-executed.

## Key Changes

- **Backend Task Manager** (`src/blueprint/task-tree-manager.ts`):
  - Added `resetInterruptedTasks()` method to reset tasks in execution states back to pending
  - Handles resetting `startedAt` and `completedAt` timestamps
  - Optional retry count reset (disabled by default since interruption isn't a failure)
  - Emits `tasks:interrupted-reset` event for monitoring

- **API Endpoint** (`src/web/server/routes/blueprint-api.ts`):
  - Added POST `/blueprints/:id/reset-interrupted` endpoint
  - Accepts optional `resetRetryCount` parameter
  - Returns count of reset tasks and task tree ID

- **Client API** (`src/web/client/src/api/blueprint.ts`):
  - Added `resetInterruptedTasks()` API client method
  - Handles response parsing and error handling

- **UI** (`src/web/client/src/pages/SwarmConsole/index.tsx`):
  - Added "Reset Interrupted Tasks" button (🔄) in the control panel
  - Includes confirmation dialog explaining the operation
  - Shows success message with count of reset tasks
  - Refreshes UI after operation

- **Version Bump**: Updated from 2.1.16 to 2.1.19

## Implementation Details

- Interrupted statuses tracked: `coding`, `testing`, `test_writing`, `review`
- Retry count is preserved by default (only reset if explicitly requested)
- Task tree statistics are recalculated after reset
- Changes are persisted to storage
- User-friendly Chinese UI labels and confirmations