### PR TITLE
Add PR-linked session management and resume functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-open",
-  "version": "2.1.20",
+  "version": "2.1.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-open",
-      "version": "2.1.20",
+      "version": "2.1.27",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.70.0",

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -64,6 +64,9 @@ import { modelConfig, type ThinkingConfig } from '../models/index.js';
 import { initAuth, getAuth, ensureOAuthApiKey } from '../auth/index.js';
 import { runPermissionRequestHooks } from '../hooks/index.js';
 import * as readline from 'readline';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
 import { setParentModelContext } from '../tools/agent.js';
 import { configManager } from '../config/index.js';
 import { accountUsageManager } from '../ratelimit/index.js';
@@ -100,6 +103,109 @@ const OUTPUT_THRESHOLD = 400000; // 400KB
 
 /** 预览大小（字节） */
 const PREVIEW_SIZE = 2000; // 2KB
+
+// ============================================================================
+// v2.1.27: 调试日志功能 - 工具失败和拒绝记录
+// ============================================================================
+
+/**
+ * 调试日志类型
+ */
+type DebugLogType = 'tool_denied' | 'tool_failed' | 'tool_error' | 'permission_denied';
+
+/**
+ * 调试日志条目
+ */
+interface DebugLogEntry {
+  timestamp: string;
+  type: DebugLogType;
+  toolName?: string;
+  reason?: string;
+  error?: string;
+  input?: unknown;
+  sessionId?: string;
+}
+
+/**
+ * 写入调试日志
+ *
+ * @param entry 调试日志条目
+ */
+function writeDebugLogEntry(entry: DebugLogEntry): void {
+  // 只有在 DEBUG 模式下才记录
+  if (!process.env.DEBUG && !process.env.CLAUDE_CODE_DEBUG) {
+    return;
+  }
+
+  try {
+    const logDir = path.join(os.homedir(), '.claude', 'logs');
+    if (!fs.existsSync(logDir)) {
+      fs.mkdirSync(logDir, { recursive: true });
+    }
+
+    const logFile = path.join(logDir, 'debug.log');
+    const logLine = JSON.stringify({
+      ...entry,
+      timestamp: entry.timestamp || new Date().toISOString(),
+    }) + '\n';
+
+    fs.appendFileSync(logFile, logLine, 'utf-8');
+  } catch {
+    // 静默忽略日志写入错误
+  }
+}
+
+/**
+ * 记录工具拒绝
+ */
+function logToolDenied(toolName: string, reason: string, sessionId?: string): void {
+  writeDebugLogEntry({
+    timestamp: new Date().toISOString(),
+    type: 'tool_denied',
+    toolName,
+    reason,
+    sessionId,
+  });
+
+  if (process.env.DEBUG) {
+    console.log(chalk.yellow(`[Debug] Tool denied: ${toolName} - ${reason}`));
+  }
+}
+
+/**
+ * 记录工具执行失败
+ */
+function logToolFailed(toolName: string, error: string, input?: unknown, sessionId?: string): void {
+  writeDebugLogEntry({
+    timestamp: new Date().toISOString(),
+    type: 'tool_failed',
+    toolName,
+    error,
+    input,
+    sessionId,
+  });
+
+  if (process.env.DEBUG) {
+    console.log(chalk.red(`[Debug] Tool failed: ${toolName} - ${error}`));
+  }
+}
+
+/**
+ * 记录权限拒绝
+ */
+function logPermissionDenied(toolName: string, reason: string, sessionId?: string): void {
+  writeDebugLogEntry({
+    timestamp: new Date().toISOString(),
+    type: 'permission_denied',
+    toolName,
+    reason,
+    sessionId,
+  });
+
+  if (process.env.DEBUG) {
+    console.log(chalk.yellow(`[Debug] Permission denied: ${toolName} - ${reason}`));
+  }
+}
 
 /**
  * 可清理的工具白名单（官方策略）
@@ -1493,9 +1599,12 @@ export class ConversationLoop {
       }
       return true;
     } else if (hookResult.decision === 'deny') {
+      const reason = hookResult.message || 'No reason provided';
       if (this.options.verbose) {
-        console.log(chalk.red(`[Permission] Denied by hook: ${hookResult.message || 'No reason provided'}`));
+        console.log(chalk.red(`[Permission] Denied by hook: ${reason}`));
       }
+      // v2.1.27: 记录到调试日志
+      logPermissionDenied(toolName, `Denied by hook: ${reason}`, this.session.sessionId);
       return false;
     }
 
@@ -1514,6 +1623,8 @@ export class ConversationLoop {
       if (this.options.verbose) {
         console.log(chalk.red('[Permission] Auto-denied in dontAsk mode'));
       }
+      // v2.1.27: 记录到调试日志
+      logPermissionDenied(toolName, 'Auto-denied in dontAsk mode', this.session.sessionId);
       return false;
     }
 
@@ -1525,6 +1636,8 @@ export class ConversationLoop {
         if (this.options.verbose) {
           console.log(chalk.yellow(`[Permission] Denied in plan mode (non-readonly tool): ${toolName}`));
         }
+        // v2.1.27: 记录到调试日志
+        logPermissionDenied(toolName, 'Denied in plan mode (non-readonly tool)', this.session.sessionId);
         return false;
       }
       // 只读工具在 plan 模式下允许执行
@@ -2004,6 +2117,11 @@ export class ConversationLoop {
             console.log(chalk.gray(result.output || result.error || ''));
           }
 
+          // v2.1.27: 记录工具执行失败到调试日志
+          if (!result.success && result.error) {
+            logToolFailed(toolName, result.error, toolInput, this.session.sessionId);
+          }
+
           // 使用格式化函数处理工具结果
           const formattedContent = formatToolResult(toolName, result);
 
@@ -2321,6 +2439,11 @@ Guidelines:
             toolResult: result.success ? result.output : undefined,
             toolError: result.success ? undefined : result.error,
           };
+
+          // v2.1.27: 记录工具执行失败到调试日志
+          if (!result.success && result.error) {
+            logToolFailed(tool.name, result.error, input, this.session.sessionId);
+          }
 
           assistantContent.push({
             type: 'tool_use',

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -4,7 +4,7 @@
  */
 
 import { ClaudeClient, type ClientConfig } from './client.js';
-import { Session } from './session.js';
+import { Session, setCurrentSessionId } from './session.js';
 import { toolRegistry } from '../tools/index.js';
 import { runWithCwd, runGeneratorWithCwd } from './cwd-context.js';
 import { isToolSearchEnabled } from '../tools/mcp.js';
@@ -1652,6 +1652,9 @@ export class ConversationLoop {
     this.options = options;
     this.promptBuilder = systemPromptBuilder;
 
+    // v2.1.27: 设置全局会话 ID 以供工具使用（如 gh pr create 自动链接）
+    setCurrentSessionId(this.session.sessionId);
+
     // 初始化提示词上下文
     this.promptContext = {
       workingDir: options.workingDir || process.cwd(),
@@ -2389,6 +2392,8 @@ Guidelines:
 
   setSession(session: Session): void {
     this.session = session;
+    // v2.1.27: 设置全局会话 ID 以供工具使用（如 gh pr create 自动链接）
+    setCurrentSessionId(session.sessionId);
   }
 
   /**

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -13,6 +13,23 @@ import { GitUtils, type GitInfo } from '../git/index.js';
 // 会话版本号
 const SESSION_VERSION = '2.0';
 
+// v2.1.27: 全局会话 ID 追踪
+let _currentSessionId: string | null = null;
+
+/**
+ * 获取当前全局会话 ID
+ */
+export function getCurrentSessionId(): string | null {
+  return _currentSessionId;
+}
+
+/**
+ * 设置当前全局会话 ID
+ */
+export function setCurrentSessionId(sessionId: string | null): void {
+  _currentSessionId = sessionId;
+}
+
 export class Session {
   private state: SessionState;
   private messages: Message[] = [];

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -18,6 +18,8 @@ import { configManager } from '../config/index.js';
 import { isBackgroundTasksDisabled } from '../utils/env-check.js';
 import { escapePathForShell } from '../utils/platform.js';
 import { getCurrentCwd } from '../core/cwd-context.js';
+import { parsePrCreateOutput, linkSessionToPr } from '../session/index.js';
+import { getCurrentSessionId } from '../core/session.js';
 import type { BashInput, BashResult, ToolDefinition } from '../types/index.js';
 
 const execAsync = promisify(exec);
@@ -655,6 +657,25 @@ Important:
         elapsedTimeSeconds,
         timeoutMs: maxTimeout,
       };
+
+      // v2.1.27: 检测 gh pr create 命令，自动链接 PR 到当前会话
+      if (command.includes('gh pr create') && result.success && result.output) {
+        const prInfo = parsePrCreateOutput(result.output);
+        if (prInfo) {
+          const sessionId = getCurrentSessionId();
+          if (sessionId) {
+            linkSessionToPr(
+              sessionId,
+              prInfo.prNumber,
+              prInfo.prUrl,
+              prInfo.prRepository
+            );
+            if (process.env.DEBUG) {
+              console.log(`[Bash] Auto-linked session to PR #${prInfo.prNumber}`);
+            }
+          }
+        }
+      }
 
       // 运行 post-tool hooks
       await runPostToolUseHooks('Bash', input, result.output || '');


### PR DESCRIPTION
## Summary
This PR adds support for linking sessions to GitHub pull requests and resuming sessions by PR number or URL. Users can now organize and resume their conversations based on associated PRs, improving workflow management for PR-based development.

## Key Changes

### CLI Enhancements
- Added `--from-pr [value]` option to resume sessions linked to a specific PR by number or URL
- Implemented interactive PR session picker when no specific PR is provided
- Added visual feedback with PR information (repository, branch, message count) in the picker UI

### Session Metadata Extensions
- Extended `SessionMetadata` interface with PR-related fields:
  - `prNumber`: Associated PR number
  - `prUrl`: Full GitHub PR URL
  - `prRepository`: Repository identifier (owner/repo format)
  - `gitBranch`: Current git branch for context

### New Session Management Functions
- `parseGitHubPrUrl()`: Parse GitHub PR URLs and extract PR information
- `linkSessionToPr()`: Associate a session with a PR
- `getSessionsByPr()`: Retrieve all sessions linked to a specific PR
- `findSessionByPr()`: Find the most recently updated session for a PR
- `parsePrCreateOutput()`: Extract PR info from `gh pr create` command output
- `setSessionGitBranch()`: Store git branch information with sessions

### UI Components
- Added `showPrSessionPicker()` function for interactive PR session selection
- Displays PR information, last updated timestamp, message count, and branch name
- Supports numbered selection for easy session resumption

## Implementation Details
- PR lookup supports both full GitHub URLs and numeric PR identifiers
- Sessions are sorted by `updatedAt` to return the most recent session when multiple exist for the same PR
- Git branch information is captured for better session context
- Graceful fallback to new session if PR session lookup fails
- Maintains backward compatibility with existing session management

https://claude.ai/code/session_015eZW6VkYkAnuJcTwhy3RFE