### PR TITLE
Upgrade to v2.1.29: Add structured outputs and improve beta handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@trpc/client": "^11.0.0",
         "@trpc/server": "^11.0.0",
         "@vscode/tree-sitter-wasm": "^0.3.0",
+        "ajv": "^8.17.1",
         "axios": "^1.6.0",
         "better-sqlite3": "^11.10.0",
         "chalk": "^5.3.0",
@@ -57,7 +58,7 @@
         "claude-web": "dist/web-cli.js"
       },
       "devDependencies": {
-        "@anthropic-ai/claude-code": "^2.1.27",
+        "@anthropic-ai/claude-code": "^2.1.29",
         "@types/better-sqlite3": "^7.6.13",
         "@types/chokidar": "^1.7.5",
         "@types/eventsource": "^1.1.15",
@@ -105,9 +106,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.27.tgz",
-      "integrity": "sha512-bmGNK5VRonYLijfMJV4dv51X8jJv4uRLER+Ng8N4AR67dlMfconhD1q+6L4U6RFVzCU1xPiYN1+eUTRaKLEFgA==",
+      "version": "2.1.29",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.29.tgz",
+      "integrity": "sha512-vMHTOXrYdnreGtKUsWdd3Bwx5fKprTyNG7shrvbx3L2/jU9jexkOJrEKmN5loeR5jrE54LSB38QpaIj8pVM6eQ==",
       "dev": true,
       "license": "SEE LICENSE IN README.md",
       "bin": {
@@ -2936,6 +2937,22 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
@@ -4552,6 +4569,28 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5597,6 +5636,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -6648,7 +6693,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@trpc/client": "^11.0.0",
     "@trpc/server": "^11.0.0",
     "@vscode/tree-sitter-wasm": "^0.3.0",
+    "ajv": "^8.17.1",
     "axios": "^1.6.0",
     "better-sqlite3": "^11.10.0",
     "chalk": "^5.3.0",
@@ -93,7 +94,7 @@
     "zod": "^3.22.0"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-code": "^2.1.27",
+    "@anthropic-ai/claude-code": "^2.1.29",
     "@types/better-sqlite3": "^7.6.13",
     "@types/chokidar": "^1.7.5",
     "@types/eventsource": "^1.1.15",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -586,15 +586,15 @@ program
         // 检查是否有 structured output 结果
         if (structuredOutputTool) {
           const session = loop.getSession();
-          const messages = session.getMessageHistory();
+          const messages = session.getMessages();
           // 查找最后一个 tool_result 消息
           for (let i = messages.length - 1; i >= 0; i--) {
             const msg = messages[i];
             if (msg.role === 'user' && Array.isArray(msg.content)) {
               const toolResult = msg.content.find((c: any) =>
-                c.type === 'tool_result' && c.content?.includes('structured_output')
-              );
-              if (toolResult) {
+                c.type === 'tool_result' && typeof c.content === 'string' && c.content.includes('structured_output')
+              ) as any;
+              if (toolResult && typeof toolResult.content === 'string') {
                 try {
                   const parsed = JSON.parse(toolResult.content);
                   if (parsed.structured_output) {

--- a/src/tools/structured-output.ts
+++ b/src/tools/structured-output.ts
@@ -1,0 +1,164 @@
+/**
+ * Structured Output 工具
+ * v2.1.29: 用于非交互模式 (-p) 的结构化输出验证
+ *
+ * 对应官方 vH6 函数和 EXA/ZD 工具定义
+ */
+
+import Ajv, { type ValidateFunction } from 'ajv';
+import { BaseTool } from './base.js';
+import type { ToolResult, ToolDefinition } from '../types/index.js';
+
+// 工具名称常量
+export const STRUCTURED_OUTPUT_TOOL_NAME = 'StructuredOutput';
+
+/**
+ * JSON Schema 类型定义
+ */
+export interface JSONSchema {
+  type?: string;
+  properties?: Record<string, any>;
+  required?: string[];
+  additionalProperties?: boolean;
+  items?: JSONSchema;
+  anyOf?: JSONSchema[];
+  oneOf?: JSONSchema[];
+  allOf?: JSONSchema[];
+  $ref?: string;
+  $defs?: Record<string, JSONSchema>;
+  definitions?: Record<string, JSONSchema>;
+  [key: string]: any;
+}
+
+/**
+ * Structured Output 工具输入
+ */
+export interface StructuredOutputInput {
+  [key: string]: any;
+}
+
+/**
+ * Structured Output 工具配置
+ */
+export interface StructuredOutputToolConfig {
+  /** JSON Schema 定义 */
+  schema: JSONSchema;
+  /** 工具名称（可选，默认为 StructuredOutput） */
+  name?: string;
+  /** 工具描述（可选） */
+  description?: string;
+}
+
+/**
+ * v2.1.29: 验证 JSON Schema 并创建 Structured Output 工具
+ * 对应官方 vH6 函数
+ *
+ * @param schema JSON Schema 定义
+ * @returns StructuredOutput 工具实例，如果 schema 无效则返回 null
+ */
+export function createStructuredOutputTool(schema: JSONSchema): StructuredOutputTool | null {
+  try {
+    const ajv = new Ajv({ allErrors: true });
+
+    // 验证 schema 是否有效
+    if (!ajv.validateSchema(schema)) {
+      console.error(`Invalid JSON Schema: ${ajv.errorsText(ajv.errors)}`);
+      return null;
+    }
+
+    // 编译 schema
+    const validate = ajv.compile(schema);
+
+    return new StructuredOutputTool(schema, validate);
+  } catch (error) {
+    console.error('Failed to create StructuredOutput tool:', error);
+    return null;
+  }
+}
+
+/**
+ * v2.1.29: Structured Output 工具
+ * 对应官方 EXA 工具定义
+ *
+ * 此工具用于验证 AI 的输出是否符合指定的 JSON Schema
+ */
+export class StructuredOutputTool extends BaseTool<StructuredOutputInput> {
+  name = STRUCTURED_OUTPUT_TOOL_NAME;
+  description = 'Provide structured output that matches the required JSON schema. Use this tool to return your response in the required format.';
+
+  private schema: JSONSchema;
+  private validate: ValidateFunction;
+
+  constructor(schema: JSONSchema, validate: ValidateFunction) {
+    super();
+    this.schema = schema;
+    this.validate = validate;
+  }
+
+  getInputSchema(): ToolDefinition['inputSchema'] {
+    // 使用用户提供的 JSON Schema 作为输入 schema
+    return this.schema as ToolDefinition['inputSchema'];
+  }
+
+  async execute(input: StructuredOutputInput): Promise<ToolResult> {
+    // 验证输入是否符合 schema
+    if (!this.validate(input)) {
+      const errors = this.validate.errors?.map(e =>
+        `${e.instancePath || 'root'}: ${e.message}`
+      ).join(', ');
+
+      return {
+        success: false,
+        error: `Output does not match required schema: ${errors}`,
+      };
+    }
+
+    // 验证通过，返回成功结果
+    // 官方实现返回 { data: "...", structured_output: z }
+    return {
+      success: true,
+      output: 'Structured output provided successfully',
+      // 附加验证后的数据
+      data: input,
+    };
+  }
+
+  /**
+   * 获取原始 schema
+   */
+  getSchema(): JSONSchema {
+    return this.schema;
+  }
+}
+
+/**
+ * v2.1.29: 解析 JSON Schema 字符串
+ *
+ * @param schemaStr JSON Schema 字符串（可以是 JSON 字符串或文件路径）
+ * @returns 解析后的 JSON Schema，如果解析失败则返回 null
+ */
+export function parseJsonSchema(schemaStr: string): JSONSchema | null {
+  try {
+    // 首先尝试直接解析为 JSON
+    return JSON.parse(schemaStr);
+  } catch {
+    // 如果解析失败，可能是文件路径
+    try {
+      const fs = require('fs');
+      const path = require('path');
+      const resolvedPath = path.resolve(schemaStr);
+
+      if (fs.existsSync(resolvedPath)) {
+        const content = fs.readFileSync(resolvedPath, 'utf-8');
+        return JSON.parse(content);
+      }
+    } catch {
+      // 忽略文件读取错误
+    }
+
+    console.error('Failed to parse JSON Schema: invalid JSON string or file path');
+    return null;
+  }
+}
+
+export default StructuredOutputTool;

--- a/src/tools/structured-output.ts
+++ b/src/tools/structured-output.ts
@@ -5,7 +5,11 @@
  * 对应官方 vH6 函数和 EXA/ZD 工具定义
  */
 
-import Ajv, { type ValidateFunction } from 'ajv';
+import AjvModule from 'ajv';
+import type { ValidateFunction } from 'ajv';
+
+// ESM 兼容：处理 default 导出
+const Ajv = (AjvModule as any).default || AjvModule;
 import { BaseTool } from './base.js';
 import type { ToolResult, ToolDefinition } from '../types/index.js';
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -9,19 +9,19 @@
  * Claude Code CLI 版本号
  * @description 当前实现版本，与官方 @anthropic-ai/claude-code 对齐
  */
-export const VERSION = '2.1.19';
+export const VERSION = '2.1.29';
 
 /**
  * 完整版本标识（带 -restored 后缀）
  * @description 用于标识这是一个还原/复刻版本
  */
-export const VERSION_FULL = '2.1.19-restored';
+export const VERSION_FULL = '2.1.29-restored';
 
 /**
  * 版本号（不带后缀）
  * @description 用于配置文件和 API 等场景
  */
-export const VERSION_BASE = '2.1.19';
+export const VERSION_BASE = '2.1.29';
 
 /**
  * 获取版本信息


### PR DESCRIPTION
## Summary
This PR upgrades the Claude Code CLI to v2.1.29, adding support for structured outputs via JSON Schema validation and significantly improving beta header handling for different provider types (firstParty, Bedrock, Vertex, Foundry).

## Key Changes

### Dependencies
- Added `ajv` (^8.17.1) for JSON Schema validation
- Updated `@anthropic-ai/claude-code` from 2.1.27 to 2.1.29

### Structured Output Support
- New `src/tools/structured-output.ts` module implementing structured output validation
- Added `--json-schema` option support in CLI for non-interactive mode (-p)
- Validates AI responses against user-provided JSON schemas using AJV
- Returns `structured_output` field in JSON output when schema validation succeeds

### Beta Header Management (v2.1.29 alignment)
- Completely rewrote `buildBetas()` function to align with official implementation
- Added new beta constants:
  - `CONTEXT_1M_BETA` - for 1M context models
  - `CONTEXT_MANAGEMENT_BETA` - context management features
  - `STRUCTURED_OUTPUTS_BETA` - structured output support
  - `WEB_SEARCH_BETA` - web search capabilities
  - `TOOL_EXAMPLES_BETA` - tool usage examples
  - `ADVANCED_TOOL_USE_BETA` - advanced tool features
  - `TOOL_SEARCH_BETA` - tool search functionality
  - `PROMPT_CACHING_SCOPE_BETA` - prompt caching scope

### Provider Type Handling
- Added `firstParty` provider type (direct Anthropic API usage)
- Implemented `isExperimentalBetasEnabled()` - only enables experimental betas for firstParty/foundry providers
- Added model capability checks:
  - `supportsStructuredOutputs()` - checks if model supports structured outputs
  - `supportsInterleavedThinking()` - checks thinking support
  - `supportsWebSearch()` - checks web search support
- Fixed beta filtering for Bedrock and Vertex gateway users to prevent validation errors

### CLI Enhancements
- Integrated structured output tool registration in conversation loop
- Added verbose logging for schema validation and tool registration
- Extracts and includes structured output results in JSON response format

## Implementation Details

The beta header logic now properly distinguishes between provider types:
- **firstParty/foundry**: Full experimental beta support
- **Bedrock/Vertex**: Limited betas (filters out unsupported ones)
- Respects `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` environment variable
- Supports custom betas via `ANTHROPIC_BETAS` environment variable

The structured output implementation uses AJV for schema validation and integrates seamlessly with the existing tool registry system, allowing AI models to return validated structured data in non-interactive mode.

## Version Update
- Updated VERSION from 2.1.19 to 2.1.29
- Updated VERSION_FULL to 2.1.29-restored
- Updated VERSION_BASE to 2.1.29

https://claude.ai/code/session_01Ab9aVXKWrLwYR1dRzPHqWD