### PR TITLE
Implement automatic timeout-to-background execution for bash commands

### DIFF
--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -103,6 +103,10 @@ export interface BashToolResult extends ToolResult {
   elapsedTimeSeconds?: number;
   /** v2.1.23: Timeout in milliseconds for display */
   timeoutMs?: number;
+  /** Background task ID when command was automatically moved to background after timeout */
+  backgroundTaskId?: string;
+  /** True if the user manually backgrounded the command (e.g. Ctrl+B) */
+  backgroundedByUser?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR implements automatic timeout-to-background execution for bash commands, aligning with the official implementation. When a command exceeds its timeout, instead of being killed, it is automatically moved to background execution and the user receives a task ID to monitor progress.

## Key Changes

- **Added `isBackgroundable()` function**: Determines whether a command supports automatic background execution. Commands like `sleep` are excluded from this feature (matching official behavior with `IgY=["sleep"]`).

- **Added `NON_BACKGROUNDABLE_COMMANDS` constant**: Maintains a list of commands that cannot be automatically backgrounded, currently containing `['sleep']`.

- **Implemented `executeWithTimeoutToBackground()` method**: New execution path that:
  - Runs commands in foreground with a timeout
  - If command completes before timeout: returns normal result
  - If timeout triggers: moves process to background without killing it
  - Returns a `backgroundTaskId` for users to query progress via TaskOutput tool
  - Manages background task lifecycle with max runtime limits

- **Updated execution flow in `execute()` method**: Added conditional logic to route commands through the new timeout-to-background path when:
  - Background tasks are not disabled
  - Command is backgroundable (not in exclusion list)

- **Extended `BashToolResult` interface**: Added two new optional fields:
  - `backgroundTaskId`: ID of background task when auto-backgrounded after timeout
  - `backgroundedByUser`: Flag to distinguish user-initiated vs automatic backgrounding

## Implementation Details

- The new method preserves existing output captured before timeout and continues writing subsequent output to a file
- Proper process lifecycle management with SIGTERM/SIGKILL escalation for background tasks
- Audit logging tracks both foreground completion and background task transitions
- Aligns with official `djA` class behavior from cli.js
- Maintains backward compatibility with existing `run_in_background` parameter

https://claude.ai/code/session_01PCAiMymPzuWCtvHM42ocRz