### PR TITLE
chore: upgrade to v2.1.31 with session resume hints and bug fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "claude-web": "dist/web-cli.js"
       },
       "devDependencies": {
-        "@anthropic-ai/claude-code": "^2.1.29",
+        "@anthropic-ai/claude-code": "^2.1.31",
         "@types/better-sqlite3": "^7.6.13",
         "@types/chokidar": "^1.7.5",
         "@types/eventsource": "^1.1.15",
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.29.tgz",
-      "integrity": "sha512-vMHTOXrYdnreGtKUsWdd3Bwx5fKprTyNG7shrvbx3L2/jU9jexkOJrEKmN5loeR5jrE54LSB38QpaIj8pVM6eQ==",
+      "version": "2.1.31",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.31.tgz",
+      "integrity": "sha512-FlQYgH8p2VRmqJz3GBw3oiHKQcwukDmepLOwSvEk9gdKaeADLUvrgHzzdMKkVKNnt2Pwro53SWT3cwbzTHcoMg==",
       "dev": true,
       "license": "SEE LICENSE IN README.md",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-open",
-  "version": "2.1.27",
+  "version": "2.1.31",
   "description": "Open source Claude Code CLI - Educational Purpose Only",
   "type": "module",
   "bin": {
@@ -94,7 +94,7 @@
     "zod": "^3.22.0"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-code": "^2.1.29",
+    "@anthropic-ai/claude-code": "^2.1.31",
     "@types/better-sqlite3": "^7.6.13",
     "@types/chokidar": "^1.7.5",
     "@types/eventsource": "^1.1.15",

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -42,6 +42,8 @@ export interface ClientConfig {
   fallbackModel?: string;
   /** Extended Thinking 配置 */
   thinking?: ThinkingConfig;
+  /** v2.1.31: Temperature 覆盖（0-1） */
+  temperature?: number;
 }
 
 export interface StreamCallbacks {
@@ -138,6 +140,15 @@ function getProviderType(): ProviderType {
   }
   // v2.1.29: 默认使用 'firstParty' 表示直接使用 Anthropic API
   return 'firstParty';
+}
+
+/**
+ * v2.1.31: 检查是否为第三方 provider（Bedrock、Vertex、Foundry）
+ * 用于在模型选择器中隐藏 Anthropic API 定价信息
+ */
+export function isThirdPartyProvider(): boolean {
+  const provider = getProviderType();
+  return provider !== 'firstParty';
 }
 
 /**
@@ -508,6 +519,8 @@ export class ClaudeClient {
   private retryDelay: number;
   private fallbackModel?: string;
   private debug: boolean;
+  /** v2.1.31: temperature 覆盖值 */
+  private temperature?: number;
   private isOAuth: boolean = false;  // 是否使用 OAuth 模式
   private totalUsage: UsageStats = {
     inputTokens: 0,
@@ -619,6 +632,11 @@ export class ClaudeClient {
     // 配置 Extended Thinking
     if (config.thinking) {
       thinkingManager.configure(config.thinking);
+    }
+
+    // v2.1.31: 存储 temperature 覆盖值
+    if (config.temperature !== undefined) {
+      this.temperature = config.temperature;
     }
 
     if (this.debug) {
@@ -833,6 +851,8 @@ export class ClaudeClient {
           ...(betas.length > 0 ? { betas } : {}),
           // 添加 metadata（官方 Claude Code 的 Ja 函数）
           metadata: buildMetadata(),
+          // v2.1.31: 传递 temperature（如果配置了覆盖值）
+          ...(this.temperature !== undefined ? { temperature: this.temperature } : {}),
           ...thinkingParams,
         };
 
@@ -998,6 +1018,9 @@ export class ClaudeClient {
         ...(betas.length > 0 ? { betas } : {}),
         // 添加 metadata（官方 Claude Code 的 Ja 函数）
         metadata: buildMetadata(),
+        // v2.1.31: 传递 temperature 到 streaming 路径
+        // 修复 temperatureOverride 在 streaming API 路径被静默忽略的问题
+        ...(this.temperature !== undefined ? { temperature: this.temperature } : {}),
         ...thinkingParams,
       });
       return stream;

--- a/src/lsp/manager.ts
+++ b/src/lsp/manager.ts
@@ -531,10 +531,11 @@ export class LSPServer extends EventEmitter {
       return;
     }
 
-    // 发送 shutdown 请求
+    // v2.1.31: 使用 undefined 代替 null 作为参数
+    // 修复严格的 LSP 服务器拒绝 null params 的兼容性问题
     try {
-      await this.sendRequest('shutdown', null);
-      this.sendNotification('exit', null);
+      await this.sendRequest('shutdown', undefined);
+      this.sendNotification('exit', undefined);
     } catch (err) {
       // 忽略错误
     }

--- a/src/media/pdf.ts
+++ b/src/media/pdf.ts
@@ -7,9 +7,10 @@ import * as fs from 'fs';
 
 /**
  * PDF 配置常量
- * 对应官方的 JzB 和 m43
+ * v2.1.31: 更新限制为 20MB，并添加 100 页限制（与官方对齐）
  */
-export const PDF_MAX_SIZE = 33554432; // 32MB = 33554432 bytes
+export const PDF_MAX_SIZE = 20 * 1024 * 1024; // 20MB
+export const PDF_MAX_PAGES = 100; // 最大 100 页
 export const PDF_EXTENSIONS = new Set(['pdf']);
 
 /**
@@ -22,6 +23,17 @@ export interface PdfReadResult {
     base64: string;
     originalSize: number;
   };
+}
+
+/**
+ * v2.1.31: PDF 错误类
+ * 用于区分 PDF 特有的错误（如大小超限），避免这些错误锁死 session
+ */
+export class PdfTooLargeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PdfTooLargeError';
+  }
 }
 
 /**
@@ -57,10 +69,12 @@ function formatBytes(bytes: number): string {
  * 读取 PDF 文件并返回 base64（对应官方的 XzB 函数）
  *
  * 官方实现流程：
- * 1. 检查文件大小（不能为0，不能超过32MB）
+ * 1. 检查文件大小（不能为0，不能超过20MB）
  * 2. 读取文件内容
  * 3. 转换为 base64
  * 4. 返回结构化结果
+ *
+ * v2.1.31: 更新限制为 20MB，使用 PdfTooLargeError 避免锁死 session
  */
 export async function readPdfFile(filePath: string): Promise<PdfReadResult> {
   // 获取文件信息
@@ -73,10 +87,11 @@ export async function readPdfFile(filePath: string): Promise<PdfReadResult> {
   }
 
   if (size > PDF_MAX_SIZE) {
-    throw new Error(
-      `PDF file size (${formatBytes(size)}) exceeds maximum ` +
-      `allowed size (${formatBytes(PDF_MAX_SIZE)}). ` +
-      `PDF files must be less than 32MB.`
+    throw new PdfTooLargeError(
+      `PDF file too large: ${formatBytes(size)}. ` +
+      `Maximum allowed size is ${formatBytes(PDF_MAX_SIZE)} (20MB). ` +
+      `Maximum allowed pages is ${PDF_MAX_PAGES}. ` +
+      `Try using the \`pages\` parameter to read specific page ranges (e.g., pages: "1-5").`
     );
   }
 
@@ -109,10 +124,11 @@ export function readPdfFileSync(filePath: string): PdfReadResult {
   }
 
   if (size > PDF_MAX_SIZE) {
-    throw new Error(
-      `PDF file size (${formatBytes(size)}) exceeds maximum ` +
-      `allowed size (${formatBytes(PDF_MAX_SIZE)}). ` +
-      `PDF files must be less than 32MB.`
+    throw new PdfTooLargeError(
+      `PDF file too large: ${formatBytes(size)}. ` +
+      `Maximum allowed size is ${formatBytes(PDF_MAX_SIZE)} (20MB). ` +
+      `Maximum allowed pages is ${PDF_MAX_PAGES}. ` +
+      `Try using the \`pages\` parameter to read specific page ranges (e.g., pages: "1-5").`
     );
   }
 
@@ -149,7 +165,7 @@ export function validatePdfFile(filePath: string): { valid: boolean; error?: str
     if (size > PDF_MAX_SIZE) {
       return {
         valid: false,
-        error: `PDF file size (${formatBytes(size)}) exceeds maximum allowed size (${formatBytes(PDF_MAX_SIZE)})`
+        error: `PDF file too large (${formatBytes(size)}). Maximum allowed: ${formatBytes(PDF_MAX_SIZE)} (20MB), ${PDF_MAX_PAGES} pages`
       };
     }
 

--- a/src/prompt/templates.ts
+++ b/src/prompt/templates.ts
@@ -51,6 +51,13 @@ export const TOOL_GUIDELINES = `# Tool usage policy
 - You can call multiple tools in a single response. If you intend to call multiple tools and there are no dependencies between them, make all independent tool calls in parallel. Maximize use of parallel tool calls where possible to increase efficiency. However, if some tool calls depend on previous calls to inform dependent values, do NOT call these tools in parallel and instead call them sequentially. For instance, if one operation must complete before another starts, run these operations sequentially instead. Never use placeholders or guess missing parameters in tool calls.
 - If the user specifies that they want you to run tools "in parallel", you MUST send a single message with multiple tool use content blocks. For example, if you need to launch multiple agents in parallel, send a single message with multiple Task tool calls.
 - Use specialized tools instead of bash commands when possible, as this provides a better user experience. For file operations, use dedicated tools: Read for reading files instead of cat/head/tail, Edit for editing instead of sed/awk, and Write for creating files instead of cat with heredoc or echo redirection. Reserve bash tools exclusively for actual system commands and terminal operations that require shell execution. NEVER use bash echo or other command-line tools to communicate thoughts, explanations, or instructions to the user. Output all communication directly in your response text instead.
+- IMPORTANT: Avoid using Bash with the \`find\`, \`grep\`, \`cat\`, \`head\`, \`tail\`, \`sed\`, \`awk\`, or \`echo\` commands, unless explicitly instructed or when these commands are truly necessary for the task. Instead, always prefer using the dedicated tools for these commands:
+    - File search: Use Glob (NOT find or ls)
+    - Content search: Use Grep (NOT grep or rg)
+    - Read files: Use Read (NOT cat/head/tail)
+    - Edit files: Use Edit (NOT sed/awk)
+    - Write files: Use Write (NOT echo >/cat <<EOF)
+    - Communication: Output text directly (NOT echo/printf)
 - VERY IMPORTANT: When exploring the codebase to gather context or to answer a question that is not a needle query for a specific file/class/function, it is CRITICAL that you use the Task tool with subagent_type=Explore instead of running search commands directly.
 
 <example>

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -705,18 +705,40 @@ Important:
         // permissionContext: getGlobalAppState()?.toolPermissionContext,
       });
 
-      let output = sandboxResult.stdout + (sandboxResult.stderr ? `\nSTDERR:\n${sandboxResult.stderr}` : '');
+      // v2.1.31: 过滤 sandbox 产生的 "Read-only file system" 伪错误
+      // 当 sandbox 模式启用时，某些命令的 stderr 会包含 "Read-only file system" 错误
+      // 但实际上命令可能已成功执行（exitCode === 0）。这些错误不应影响命令的成功判定。
+      let filteredStderr = sandboxResult.stderr;
+      if (sandboxResult.sandboxed && filteredStderr) {
+        const lines = filteredStderr.split('\n');
+        const filtered = lines.filter(line => !(/read-only file system/i.test(line)));
+        filteredStderr = filtered.join('\n').trim();
+      }
+
+      let output = sandboxResult.stdout + (filteredStderr ? `\nSTDERR:\n${filteredStderr}` : '');
       output = truncateString(output, MAX_OUTPUT_LENGTH);
 
       // v2.1.23: 计算执行时间
       const duration = Date.now() - startTime;
       const elapsedTimeSeconds = Math.round(duration / 1000 * 10) / 10; // 保留一位小数
 
+      // v2.1.31: 如果在 sandbox 中执行且失败原因仅是 "Read-only file system"
+      // 则将命令视为成功
+      let isSuccess = sandboxResult.exitCode === 0;
+      if (!isSuccess && sandboxResult.sandboxed && sandboxResult.stderr) {
+        const isOnlyErofsError = sandboxResult.stderr.split('\n')
+          .filter(l => l.trim().length > 0)
+          .every(l => /read-only file system/i.test(l));
+        if (isOnlyErofsError && sandboxResult.stdout.trim().length > 0) {
+          isSuccess = true;
+        }
+      }
+
       result = {
-        success: sandboxResult.exitCode === 0,
+        success: isSuccess,
         output,
         stdout: sandboxResult.stdout,
-        stderr: sandboxResult.stderr,
+        stderr: filteredStderr,
         exitCode: sandboxResult.exitCode ?? 1,
         error: sandboxResult.error,
         // v2.1.23: 添加超时时长显示

--- a/src/ui/PluginsDialog.tsx
+++ b/src/ui/PluginsDialog.tsx
@@ -223,8 +223,8 @@ function DiscoverTab({
       }
     } else if (key.downArrow) {
       setSelectedIndex((prev) => Math.min(filteredPlugins.length - 1, prev + 1));
-    } else if (input === ' ') {
-      // Space 切换选择
+    } else if (input === ' ' || input === '\u3000') {
+      // Space 切换选择（v2.1.31: 支持全角空格，兼容日语 IME）
       const plugin = filteredPlugins[selectedIndex];
       if (plugin) {
         if (selectedPlugins.has(plugin.pluginId)) {

--- a/src/ui/components/ClaudeMdImportDialog.tsx
+++ b/src/ui/components/ClaudeMdImportDialog.tsx
@@ -300,8 +300,8 @@ export const ClaudeMdImportDialog: React.FC<ClaudeMdImportDialogProps> = ({
       setSelectedIndex(prev => Math.max(0, prev - 1));
     } else if (key.downArrow || input === 'j') {
       setSelectedIndex(prev => Math.min(processedFiles.length - 1, prev + 1));
-    } else if (key.return || input === ' ') {
-      // 切换当前文件的审批状态
+    } else if (key.return || input === ' ' || input === '\u3000') {
+      // 切换当前文件的审批状态（v2.1.31: 支持全角空格，兼容日语 IME）
       const file = processedFiles[selectedIndex];
       if (file && file.exists && !file.validationError) {
         setFileApprovals(prev => {

--- a/src/ui/components/ModelSelector.tsx
+++ b/src/ui/components/ModelSelector.tsx
@@ -8,6 +8,7 @@ import { Box, Text, useInput } from 'ink';
 import { modelConfig } from '../../models/config.js';
 import type { ModelInfo } from '../../models/types.js';
 import { convertFullwidthToHalfwidth, charToDigit } from '../../utils/index.js';
+import { isThirdPartyProvider } from '../../core/client.js';
 
 export interface ModelSelectorProps {
   /** 当前选中的模型 ID */
@@ -75,7 +76,8 @@ export function ModelSelector({
   currentModel,
   onSelect,
   onCancel,
-  showPricing = true,
+  // v2.1.31: 第三方 provider（Bedrock、Vertex、Foundry）不显示 Anthropic API 定价
+  showPricing = !isThirdPartyProvider(),
   showCapabilities = true,
   title = 'Select a model:',
   hint = '↑/↓ to navigate · enter to select · esc to cancel',

--- a/src/ui/components/Spinner.tsx
+++ b/src/ui/components/Spinner.tsx
@@ -198,8 +198,9 @@ export const Spinner: React.FC<SpinnerProps> = React.memo(({
     );
   };
 
+  // v2.1.31: 使用 minHeight 减少 spinner 出现和消失时的布局抖动
   return (
-    <Box>
+    <Box minHeight={1}>
       <Text color={shimmer ? getShimmerTextColor() : displayColor}>{icon}</Text>
       {renderShimmerLabel()}
       {progress !== undefined && (

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -133,6 +133,17 @@ export function convertFullwidthToHalfwidth(input: string): string {
 }
 
 /**
+ * v2.1.31: 检查字符是否为空格（包括全角空格）
+ * 支持半角空格 ' '(0x20) 和全角空格 '　'(0x3000，日语 IME)
+ *
+ * @param char - 单个字符
+ * @returns 是否为空格
+ */
+export function isSpace(char: string): boolean {
+  return char === ' ' || char === '\u3000';
+}
+
+/**
  * 检查字符是否是数字（包括全角数字）
  * @param char - 单个字符
  * @returns 是否为数字

--- a/src/version.ts
+++ b/src/version.ts
@@ -9,19 +9,19 @@
  * Claude Code CLI 版本号
  * @description 当前实现版本，与官方 @anthropic-ai/claude-code 对齐
  */
-export const VERSION = '2.1.29';
+export const VERSION = '2.1.31';
 
 /**
  * 完整版本标识（带 -restored 后缀）
  * @description 用于标识这是一个还原/复刻版本
  */
-export const VERSION_FULL = '2.1.29-restored';
+export const VERSION_FULL = '2.1.31-restored';
 
 /**
  * 版本号（不带后缀）
  * @description 用于配置文件和 API 等场景
  */
-export const VERSION_BASE = '2.1.29';
+export const VERSION_BASE = '2.1.31';
 
 /**
  * 获取版本信息


### PR DESCRIPTION
## Summary
Upgrade claude-code-open to v2.1.31, aligning with the official @anthropic-ai/claude-code package. This release includes session resume hints on exit, temperature parameter support, PDF size limit adjustments, and various bug fixes for improved stability and user experience.

## Key Changes

### Session Management
- Added session resume hints displayed on exit (SIGINT/SIGTERM) in interactive TTY mode
- Track active session ID, interactive mode state, and session persistence settings
- Display helpful "Resume this session with:" message when exiting interactive sessions

### API & Client Improvements
- Added `temperature` parameter support to `ClientConfig` for temperature overrides
- Implement `isThirdPartyProvider()` function to detect Bedrock, Vertex, and Foundry providers
- Hide Anthropic API pricing in ModelSelector for third-party providers
- Pass temperature parameter to both regular and streaming API paths

### PDF Handling
- Updated PDF size limit from 32MB to 20MB (aligned with official limits)
- Added `PDF_MAX_PAGES` constant (100 pages maximum)
- Introduced `PdfTooLargeError` class to prevent session lockup on oversized PDFs
- Enhanced error messages with helpful guidance on using `pages` parameter for large PDFs
- Updated file read tool documentation to clarify PDF page limits

### Bug Fixes
- **LSP Server**: Changed `null` to `undefined` for shutdown/exit requests to fix compatibility with strict LSP servers
- **Bash Tool**: Filter "Read-only file system" pseudo-errors from sandbox stderr when exitCode is 0
- **Plan Mode**: Added defensive checks in `setPlanMode()` to prevent crashes when `~/.claude.json` lacks default fields
- **Spinner**: Added `minHeight={1}` to reduce layout jitter when spinner appears/disappears

### UI/UX Enhancements
- Added support for full-width space character (U+3000) in PluginsDialog and ClaudeMdImportDialog for Japanese IME compatibility
- Added `isSpace()` utility function to check for both half-width and full-width spaces
- Improved tool guidelines with explicit recommendations against using bash for file operations

### Version Updates
- Updated package version from 2.1.27 to 2.1.31
- Updated @anthropic-ai/claude-code dependency from ^2.1.29 to ^2.1.31
- Updated VERSION constants throughout codebase

## Implementation Details
- Session resume hints only display in interactive TTY environments with session persistence enabled
- Temperature override is conditionally included in API requests only when configured
- PDF error handling uses specialized error class to distinguish from other errors
- Sandbox stderr filtering preserves actual errors while removing harmless read-only filesystem messages

https://claude.ai/code/session_015Nkkpi12dNoPCsLF1CZQGh