### PR TITLE
feat: add custom install directory and proxy auto-detection

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -22,7 +22,7 @@ $RepoUrlGithub = "https://github.com/kill136/claude-code-open.git"
 $RepoUrlGitee  = "https://gitee.com/lubanbbs/claude-code-open.git"
 $RepoUrl       = ""  # Will be set by Detect-RepoUrl
 $DockerImage   = "wbj66/axon:latest"
-$InstallDir    = "$env:USERPROFILE\.axon"
+$InstallDir    = if ($env:AXON_CONFIG_DIR) { $env:AXON_CONFIG_DIR } else { "$env:USERPROFILE\.axon" }
 $NodeMajorRequired = 18
 $NodeMajorMax = 22  # LTS; native modules may lack prebuilds for newer versions
 
@@ -52,6 +52,29 @@ function Detect-RepoUrl {
     if ($script:RepoUrl) {
         Write-Info "Using user-specified repo: $script:RepoUrl"
         return
+    }
+
+    # Auto-detect system proxy and configure git to use it
+    $proxy = $null
+    try {
+        $reg = Get-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings" -ErrorAction SilentlyContinue
+        if ($reg.ProxyEnable -eq 1 -and $reg.ProxyServer) {
+            $proxy = $reg.ProxyServer
+            if ($proxy -notmatch '^https?://') { $proxy = "http://$proxy" }
+        }
+    } catch {}
+    # Also check common env vars
+    if (-not $proxy) {
+        $proxy = $env:HTTPS_PROXY
+        if (-not $proxy) { $proxy = $env:HTTP_PROXY }
+        if (-not $proxy) { $proxy = $env:https_proxy }
+        if (-not $proxy) { $proxy = $env:http_proxy }
+    }
+    if ($proxy) {
+        Write-Info "Detected proxy: $proxy, configuring git..."
+        git config --global http.proxy $proxy 2>$null
+        git config --global https.proxy $proxy 2>$null
+        $script:GitProxyConfigured = $true
     }
 
     Write-Info "Detecting network connectivity..."
@@ -520,7 +543,8 @@ function New-LauncherScript {
     $LauncherPath = Join-Path $LauncherDir "claude-web-start.bat"
 
     # This launcher lives outside git repo, so git operations never break it
-    $LauncherContent = @'
+    # Use PowerShell variable to inject the actual install path into the bat template
+    $LauncherContent = @"
 @echo off
 chcp 65001 >nul 2>&1
 setlocal enabledelayedexpansion
@@ -531,7 +555,12 @@ echo   ^|            Axon - WebUI                     ^|
 echo   +=============================================+
 echo.
 
-set "INSTALL_DIR=%USERPROFILE%\.axon"
+REM Use AXON_CONFIG_DIR if set, otherwise fall back to the path chosen at install time
+if defined AXON_CONFIG_DIR (
+    set "INSTALL_DIR=%AXON_CONFIG_DIR%"
+) else (
+    set "INSTALL_DIR=$InstallPath"
+)
 
 if not exist "%INSTALL_DIR%" (
     echo [ERROR] Installation directory not found: %INSTALL_DIR%
@@ -539,6 +568,10 @@ if not exist "%INSTALL_DIR%" (
     goto :error_exit
 )
 cd /d "%INSTALL_DIR%"
+"@
+
+    # The rest of the launcher is static, use single-quoted here-string
+    $LauncherContent += @'
 
 REM --- Determine which node.exe to use ---
 REM Priority 1: portable Node.js in .node/ (always wins if present)
@@ -747,6 +780,23 @@ function Clone-Repository {
     git clone -b private_web_ui --progress $RepoUrl $InstallDir 2>&1 | Write-Host
     $cloneExit = $LASTEXITCODE
     $ErrorActionPreference = $prevEAP
+
+    # If GitHub clone failed, automatically fall back to Gitee mirror
+    if ($cloneExit -ne 0 -and $RepoUrl -eq $script:RepoUrlGithub) {
+        Write-Warn "GitHub clone failed, falling back to Gitee mirror..."
+        # Clean up partial clone
+        if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir }
+        $prevEAP = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        git clone -b private_web_ui --progress $script:RepoUrlGitee $InstallDir 2>&1 | Write-Host
+        $cloneExit = $LASTEXITCODE
+        $ErrorActionPreference = $prevEAP
+        if ($cloneExit -eq 0) {
+            $script:RepoUrl = $script:RepoUrlGitee
+            Write-Ok "Cloned from Gitee mirror successfully"
+        }
+    }
+
     if ($cloneExit -ne 0) {
         Write-Error "Git clone failed (exit code $cloneExit). Please check your network connection and try again."
     }
@@ -981,6 +1031,25 @@ function Main {
         Uninstall
         return
     }
+
+    # Prompt user for installation directory
+    Write-Host "  Install directory: " -ForegroundColor White -NoNewline
+    Write-Host "$InstallDir" -ForegroundColor Cyan
+    Write-Host "  Press Enter to accept, or type a new path:" -ForegroundColor DarkGray
+    $customDir = Read-Host "  "
+    if (-not [string]::IsNullOrWhiteSpace($customDir)) {
+        $script:InstallDir = $customDir.Trim().TrimEnd('\')
+    }
+    Write-Ok "Installation directory: $InstallDir"
+
+    # Persist AXON_CONFIG_DIR if user chose a non-default path
+    $DefaultDir = "$env:USERPROFILE\.axon"
+    if ($InstallDir -ne $DefaultDir) {
+        [Environment]::SetEnvironmentVariable("AXON_CONFIG_DIR", $InstallDir, "User")
+        $env:AXON_CONFIG_DIR = $InstallDir
+        Write-Ok "Saved AXON_CONFIG_DIR=$InstallDir to user environment variables"
+    }
+    Write-Host ""
 
     Write-Info "Checking & installing dependencies..."
     Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ REPO_URL_GITHUB="https://github.com/kill136/claude-code-open.git"
 REPO_URL_GITEE="https://gitee.com/lubanbbs/claude-code-open.git"
 REPO_URL=""  # Will be set by detect_repo_url()
 DOCKER_IMAGE="wbj66/axon:latest"
-INSTALL_DIR="$HOME/.axon"
+INSTALL_DIR="${AXON_CONFIG_DIR:-$HOME/.axon}"
 NODE_MAJOR_REQUIRED=18
 NODE_MAJOR_MAX=22  # LTS; native modules may lack prebuilds for newer versions
 NODE_HEAP_MB=3072  # Node.js max heap size for npm install (prevents OOM on low-memory devices)
@@ -57,6 +57,14 @@ detect_repo_url() {
     if [ -n "$REPO_URL" ]; then
         info "Using user-specified repo: $REPO_URL"
         return
+    fi
+
+    # Auto-detect system proxy and configure git to use it
+    local proxy="${HTTPS_PROXY:-${HTTP_PROXY:-${https_proxy:-${http_proxy:-}}}}"
+    if [ -n "$proxy" ]; then
+        info "Detected proxy: $proxy, configuring git..."
+        git config --global http.proxy "$proxy" 2>/dev/null
+        git config --global https.proxy "$proxy" 2>/dev/null
     fi
 
     info "Detecting network connectivity..."
@@ -568,7 +576,7 @@ CYAN='\033[0;36m'
 BOLD='\033[1m'
 NC='\033[0m'
 
-INSTALL_DIR="$HOME/.axon"
+INSTALL_DIR="${AXON_CONFIG_DIR:-$HOME/.axon}"
 
 info()    { echo -e "${BLUE}[INFO]${NC} $*"; }
 success() { echo -e "${GREEN}[OK]${NC} $*"; }
@@ -716,7 +724,7 @@ EOF
             SHORTCUT_FILE="$DESKTOP_DIR/Axon WebUI.command"
             cat > "$SHORTCUT_FILE" << EOF
 #!/bin/bash
-"$HOME/.axon/update-and-start.sh" &
+"${AXON_CONFIG_DIR:-$HOME/.axon}/update-and-start.sh" &
 APP_PID=\$!
 # Wait for server to start and open browser
 sleep 3
@@ -791,6 +799,27 @@ EOF
 # Install methods
 # ============================================
 
+clone_with_fallback() {
+    info "Cloning repository... (this may take a while)"
+    if git clone -b private_web_ui "$REPO_URL" "$INSTALL_DIR"; then
+        return 0
+    fi
+
+    # Clone failed — try Gitee fallback if we were using GitHub
+    if [ "$REPO_URL" = "$REPO_URL_GITHUB" ]; then
+        warn "GitHub clone failed, falling back to Gitee mirror..."
+        rm -rf "$INSTALL_DIR"
+        REPO_URL="$REPO_URL_GITEE"
+        if git clone -b private_web_ui "$REPO_URL" "$INSTALL_DIR"; then
+            success "Cloned from Gitee mirror successfully"
+            return 0
+        fi
+        error "Git clone failed from both GitHub and Gitee. Please check your network connection."
+    else
+        error "Git clone failed. Please check your network connection and try again."
+    fi
+}
+
 install_npm() {
     info "Installing via npm (from source)..."
 
@@ -808,19 +837,11 @@ install_npm() {
         else
             warn "Existing directory is not a git repository. Removing and re-installing..."
             rm -rf "$INSTALL_DIR"
-            info "Cloning repository..."
-            git clone -b private_web_ui "$REPO_URL" "$INSTALL_DIR"
-            if [ $? -ne 0 ]; then
-                error "Git clone failed. Please check your network connection and try again."
-            fi
+            clone_with_fallback
             cd "$INSTALL_DIR"
         fi
     else
-        info "Cloning repository..."
-        git clone -b private_web_ui "$REPO_URL" "$INSTALL_DIR"
-        if [ $? -ne 0 ]; then
-            error "Git clone failed. Please check your network connection and try again."
-        fi
+        clone_with_fallback
         cd "$INSTALL_DIR"
     fi
 
@@ -1037,6 +1058,33 @@ main() {
 
     detect_platform
     detect_pkg_manager
+    echo ""
+
+    # ---- Prompt for installation directory ----
+    echo -e "  ${BOLD}Install directory:${NC} ${CYAN}$INSTALL_DIR${NC}"
+    echo -e "  ${BOLD}Press Enter to accept, or type a new path:${NC}"
+    if [ -t 0 ] || [ -e /dev/tty ]; then
+        read -p "  " custom_dir < /dev/tty
+        if [ -n "$custom_dir" ]; then
+            INSTALL_DIR="${custom_dir%/}"
+        fi
+    fi
+    success "Installation directory: $INSTALL_DIR"
+
+    # Persist AXON_CONFIG_DIR if user chose a non-default path
+    DEFAULT_DIR="$HOME/.axon"
+    if [ "$INSTALL_DIR" != "$DEFAULT_DIR" ]; then
+        export AXON_CONFIG_DIR="$INSTALL_DIR"
+        # Add to shell rc files
+        for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
+            if [ -f "$rc" ]; then
+                if ! grep -q 'AXON_CONFIG_DIR' "$rc"; then
+                    echo "export AXON_CONFIG_DIR=\"$INSTALL_DIR\"" >> "$rc"
+                fi
+            fi
+        done
+        success "Saved AXON_CONFIG_DIR=$INSTALL_DIR to shell config"
+    fi
     echo ""
 
     # ---- Auto-install ALL dependencies ----


### PR DESCRIPTION
Add support for AXON_CONFIG_DIR environment variable to allow custom installation paths. Auto-detect system proxy settings and configure git accordingly. Implement fallback to Gitee mirror if GitHub clone fails. Add interactive prompt during installation to let users choose installation directory, with persistence via environment variables.

## Summary

<!-- What does this PR do? Keep it concise. -->

## Changes

- 

## Related Issue

<!-- Link to the issue this PR addresses, e.g., Fixes #123 -->

## Testing

- [ ] `npx tsc --noEmit` passes
- [ ] `npm test -- --run` passes
- [ ] Manually tested in CLI mode
- [ ] Manually tested in Web UI mode

## Screenshots

<!-- If applicable, add screenshots or GIFs -->
