### PR TITLE
fix: stabilize layered memory recall across projects

### DIFF
--- a/src/memory/long-term-store.ts
+++ b/src/memory/long-term-store.ts
@@ -93,6 +93,7 @@ export class LongTermStore {
         'Original error: ' + (e.message)
       );
     });
+    ensureDir(path.dirname(dbPath));
     this.db = new mod.default(dbPath);
 
     // 尝试加载 sqlite-vec 扩展

--- a/src/memory/memory-search.ts
+++ b/src/memory/memory-search.ts
@@ -15,6 +15,7 @@ import { createOpenAIEmbeddingProvider, type EmbeddingProvider } from './embeddi
 import { EmbeddingCache } from './embedding-cache.js';
 import { mergeHybridResults } from './hybrid-search.js';
 import { applyMMRToResults, type MMRConfig } from './mmr.js';
+import { getCurrentCwd, isInCwdContext } from '../core/cwd-context.js';
 
 /**
  * 搜索选项
@@ -84,6 +85,20 @@ function getClaudeDir(): string {
  */
 function hashProjectPath(projectPath: string): string {
   return crypto.createHash('md5').update(projectPath).digest('hex').slice(0, 12);
+}
+
+function normalizeProjectPath(projectPath: string): string {
+  const normalized = path.resolve(projectPath).replace(/\\/g, '/');
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}
+
+const GLOBAL_MAP_KEY = '__axon_memory_search_managers__' as const;
+
+function getManagersMap(): Map<string, MemorySearchManager> {
+  if (!(globalThis as any)[GLOBAL_MAP_KEY]) {
+    (globalThis as any)[GLOBAL_MAP_KEY] = new Map<string, MemorySearchManager>();
+  }
+  return (globalThis as any)[GLOBAL_MAP_KEY];
 }
 
 /**
@@ -465,28 +480,78 @@ export async function initMemorySearchManager(
   projectHash: string,
   embeddingConfig?: EmbeddingConfig,
 ): Promise<MemorySearchManager> {
-  // Close previous instance to avoid SQLite connection leak
-  if (managerInstance) {
-    try { managerInstance.close(); } catch { /* ignore */ }
+  const key = normalizeProjectPath(projectDir);
+  const map = getManagersMap();
+  const existing = map.get(key);
+  if (existing) {
+    try { existing.close(); } catch { /* ignore */ }
   }
+
   const resolved = resolveEmbeddingConfig(embeddingConfig);
   managerInstance = await MemorySearchManager.create({ projectDir, projectHash, embeddingConfig: resolved });
+  map.set(key, managerInstance);
   return managerInstance;
+}
+
+export async function ensureMemorySearchManager(
+  projectDir: string,
+  embeddingConfig?: EmbeddingConfig,
+): Promise<MemorySearchManager> {
+  const existing = getMemorySearchManager(projectDir);
+  if (existing) {
+    return existing;
+  }
+
+  return initMemorySearchManager(projectDir, hashProjectPath(projectDir), embeddingConfig);
 }
 
 /**
  * 获取 MemorySearchManager 实例
  */
-export function getMemorySearchManager(): MemorySearchManager | null {
+export function getMemorySearchManager(projectDir?: string): MemorySearchManager | null {
+  const map = getManagersMap();
+
+  if (projectDir) {
+    const manager = map.get(normalizeProjectPath(projectDir)) || null;
+    if (manager) {
+      managerInstance = manager;
+    }
+    return manager;
+  }
+
+  if (isInCwdContext()) {
+    const manager = map.get(normalizeProjectPath(getCurrentCwd())) || null;
+    if (manager) {
+      managerInstance = manager;
+      return manager;
+    }
+  }
+
   return managerInstance;
 }
 
 /**
  * 重置 MemorySearchManager 实例
  */
-export function resetMemorySearchManager(): void {
-  if (managerInstance) {
-    managerInstance.close();
-    managerInstance = null;
+export function resetMemorySearchManager(projectDir?: string): void {
+  const map = getManagersMap();
+
+  if (projectDir) {
+    const key = normalizeProjectPath(projectDir);
+    const manager = map.get(key);
+    if (manager) {
+      try { manager.close(); } catch { /* ignore */ }
+      map.delete(key);
+      if (managerInstance === manager) {
+        managerInstance = null;
+      }
+    }
+    return;
   }
+
+  for (const manager of map.values()) {
+    try { manager.close(); } catch { /* ignore */ }
+  }
+  map.clear();
+  managerInstance = null;
 }

--- a/src/memory/memory-sync.ts
+++ b/src/memory/memory-sync.ts
@@ -57,6 +57,17 @@ async function listMarkdownFiles(dir: string): Promise<string[]> {
   }
 }
 
+function normalizeProjectPathForCompare(projectPath: string | null | undefined): string | null {
+  if (!projectPath || !projectPath.trim()) return null;
+
+  try {
+    const normalized = path.resolve(projectPath).replace(/\\/g, '/');
+    return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * 计算文件 hash (SHA-256)
  */
@@ -356,7 +367,6 @@ export class MemorySyncEngine {
       for (const dirent of jsonFiles) {
         const absPath = path.join(transcriptsDir, dirent.name);
         const indexPath = `transcript:${dirent.name}`;
-        processedPaths.add(indexPath);
 
         try {
           const stat = await fs.stat(absPath);
@@ -379,6 +389,12 @@ export class MemorySyncEngine {
           } catch {
             continue; // 跳过损坏的 JSON
           }
+
+          if (!this.shouldIndexTranscriptForCurrentProject(data)) {
+            continue;
+          }
+
+          processedPaths.add(indexPath);
 
           // 提取对话文本
           const markdown = this.extractTranscriptMarkdown(data);
@@ -417,6 +433,40 @@ export class MemorySyncEngine {
     }
 
     return result;
+  }
+
+  /**
+   * 判断 transcript 是否属于当前项目。
+   * 没有可判定的工作目录时，宁可不索引，避免把其他项目会话混进当前项目 recall。
+   */
+  private shouldIndexTranscriptForCurrentProject(data: any): boolean {
+    if (!this.projectDir) return true;
+
+    const transcriptProjectPath = this.extractTranscriptProjectPath(data);
+    if (!transcriptProjectPath) return false;
+
+    return normalizeProjectPathForCompare(transcriptProjectPath) === normalizeProjectPathForCompare(this.projectDir);
+  }
+
+  /**
+   * 从 transcript JSON 中提取所属项目路径。
+   */
+  private extractTranscriptProjectPath(data: any): string | null {
+    const metadata = data?.metadata;
+
+    const candidates = [
+      metadata?.projectPath,
+      metadata?.workingDirectory,
+      data?.state?.cwd,
+    ];
+
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim().length > 0) {
+        return candidate;
+      }
+    }
+
+    return null;
   }
 
   /**

--- a/src/memory/recall-planner.ts
+++ b/src/memory/recall-planner.ts
@@ -7,6 +7,7 @@ export interface LayeredRecallOptions {
   hasCompactSummary?: boolean;
   notebookLimit?: number;
   sessionSummaryLimit?: number;
+  transcriptLimit?: number;
   searchPoolSize?: number;
 }
 
@@ -14,6 +15,7 @@ export interface LayeredRecallPlan {
   formatted: string | null;
   notebookResults: MemorySearchResult[];
   sessionSummaryResults: MemorySearchResult[];
+  transcriptResults: MemorySearchResult[];
 }
 
 function formatAge(ms: number): string {
@@ -37,6 +39,17 @@ function sanitizeSummaryText(snippet: string): string {
     .trim();
 }
 
+function sanitizeTranscriptText(snippet: string): string {
+  return snippet
+    .replace(/^#\s+.*$/gm, '')
+    .replace(/^Date:\s+.*$/gm, '')
+    .replace(/^Model:\s+.*$/gm, '')
+    .replace(/^Project:\s+.*$/gm, '')
+    .replace(/^##\s+(User|Assistant)\s*$/gm, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
 function isCurrentSessionSummary(result: MemorySearchResult, sessionId?: string): boolean {
   if (!sessionId) return false;
   if (getRecallSourceKind(result) !== 'session-summary') return false;
@@ -44,6 +57,10 @@ function isCurrentSessionSummary(result: MemorySearchResult, sessionId?: string)
   return normalized === `${sessionId}/session-memory/summary.md`
     || normalized.endsWith(`/${sessionId}/session-memory/summary.md`)
     || normalized.endsWith(`${sessionId}/session-memory/summary.md`);
+}
+
+function isTranscriptResult(result: MemorySearchResult): boolean {
+  return getRecallSourceKind(result) === 'transcript';
 }
 
 function dedupeSecondaryBySnippet(
@@ -65,9 +82,12 @@ function formatSection(title: string, results: MemorySearchResult[]): string | n
 
   const lines = [title];
   for (const result of results) {
-    const text = getRecallSourceKind(result) === 'session-summary'
+    const sourceKind = getRecallSourceKind(result);
+    const text = sourceKind === 'session-summary'
       ? sanitizeSummaryText(result.snippet)
-      : result.snippet;
+      : sourceKind === 'transcript'
+        ? sanitizeTranscriptText(result.snippet)
+        : result.snippet;
     lines.push(`- (${formatAge(result.age)} ago) ${text}`);
   }
   return lines.join('\n');
@@ -79,6 +99,7 @@ export function planLayeredRecallFromResults(
 ): LayeredRecallPlan {
   const notebookLimit = opts.notebookLimit ?? 2;
   const sessionSummaryLimit = opts.sessionSummaryLimit ?? 1;
+  const transcriptLimit = opts.transcriptLimit ?? 0;
 
   const notebookResults = results
     .filter(result => getRecallSourceKind(result) === 'notebook')
@@ -92,15 +113,24 @@ export function planLayeredRecallFromResults(
     ).slice(0, sessionSummaryLimit);
   }
 
+  const transcriptResults = transcriptLimit > 0
+    ? dedupeSecondaryBySnippet(
+        [...notebookResults, ...sessionSummaryResults],
+        results.filter(result => isTranscriptResult(result)),
+      ).slice(0, transcriptLimit)
+    : [];
+
   const sections = [
     formatSection('[Notebook]', notebookResults),
     formatSection('[Current session background]', sessionSummaryResults),
+    formatSection('[Past session evidence]', transcriptResults),
   ].filter((section): section is string => Boolean(section));
 
   return {
     formatted: sections.length > 0 ? sections.join('\n\n') : null,
     notebookResults,
     sessionSummaryResults,
+    transcriptResults,
   };
 }
 
@@ -114,14 +144,16 @@ export async function buildLayeredMemoryRecall(
       formatted: null,
       notebookResults: [],
       sessionSummaryResults: [],
+      transcriptResults: [],
     };
   }
 
   const notebookLimit = opts.notebookLimit ?? 2;
   const sessionSummaryLimit = opts.sessionSummaryLimit ?? 1;
+  const transcriptLimit = opts.transcriptLimit ?? 1;
   const searchPoolSize = opts.searchPoolSize ?? 8;
 
-  const [notebookRaw, sessionRaw] = await Promise.all([
+  const [notebookRaw, sessionRaw, transcriptRaw] = await Promise.all([
     manager.hybridSearch(query, {
       source: 'notebook',
       maxResults: Math.max(searchPoolSize, notebookLimit * 2),
@@ -132,6 +164,12 @@ export async function buildLayeredMemoryRecall(
           source: 'session',
           maxResults: Math.max(searchPoolSize, sessionSummaryLimit * 4),
         }),
+    transcriptLimit > 0
+      ? manager.hybridSearch(query, {
+          source: 'session',
+          maxResults: Math.max(searchPoolSize, transcriptLimit * 6),
+        })
+      : Promise.resolve([]),
   ]);
 
   const notebookResults = notebookRaw
@@ -145,14 +183,23 @@ export async function buildLayeredMemoryRecall(
         sessionRaw.filter(result => result.score > 0.1 && isCurrentSessionSummary(result, opts.sessionId)),
       ).slice(0, sessionSummaryLimit);
 
+  const transcriptResults = transcriptLimit > 0
+    ? dedupeSecondaryBySnippet(
+        [...notebookResults, ...sessionSummaryResults],
+        transcriptRaw.filter(result => result.score > 0.1 && isTranscriptResult(result)),
+      ).slice(0, transcriptLimit)
+    : [];
+
   const sections = [
     formatSection('[Notebook]', notebookResults),
     formatSection('[Current session background]', sessionSummaryResults),
+    formatSection('[Past session evidence]', transcriptResults),
   ].filter((section): section is string => Boolean(section));
 
   return {
     formatted: sections.length > 0 ? sections.join('\n\n') : null,
     notebookResults,
     sessionSummaryResults,
+    transcriptResults,
   };
 }

--- a/src/web/server/conversation.ts
+++ b/src/web/server/conversation.ts
@@ -41,7 +41,8 @@ import {
   isEmptyTemplate,
 } from '../../context/session-memory.js';
 import { initNotebookManager, getNotebookManager, activateNotebookManager } from '../../memory/notebook.js';
-import { initMemorySearchManager, getMemorySearchManager } from '../../memory/memory-search.js';
+import { initMemorySearchManager, getMemorySearchManager, ensureMemorySearchManager } from '../../memory/memory-search.js';
+import { buildLayeredMemoryRecall } from '../../memory/recall-planner.js';
 import { registerMcpServer, connectMcpServer, createMcpTools, getMcpServers, callMcpTool, disconnectMcpServer, unregisterMcpServer, MCPSearchTool, isThirdPartyApiEndpoint, getMcpMode, type McpToolDefinition } from '../../tools/mcp.js';
 import { isDeferredTool } from '../../mcp/tools.js';
 import { getChromeIntegrationConfig } from '../../chrome-mcp/index.js';
@@ -4327,6 +4328,42 @@ Respond ONLY with valid JSON, no other text.`;
     return langMap[ext || ''] || 'text';
   }
 
+  private extractRecallQuery(content: string | ContentBlock[] | unknown): string | null {
+    if (typeof content === 'string') {
+      const text = content.trim();
+      return text.length > 0 ? text : null;
+    }
+
+    if (!Array.isArray(content)) {
+      return null;
+    }
+
+    const text = content
+      .filter((block: any) => block?.type === 'text' && typeof block.text === 'string')
+      .map((block: any) => block.text.trim())
+      .filter(Boolean)
+      .join('\n')
+      .trim();
+
+    return text.length > 0 ? text : null;
+  }
+
+  private getLatestUserRecallQuery(state: SessionState): string | null {
+    for (let i = state.messages.length - 1; i >= 0; i--) {
+      const message = state.messages[i];
+      if (message.role !== 'user') {
+        continue;
+      }
+
+      const query = this.extractRecallQuery(message.content);
+      if (query) {
+        return query;
+      }
+    }
+
+    return null;
+  }
+
   /**
    * 构建系统提示（与 CLI 完全一致，仅在末尾追加记忆单元）
    */
@@ -4350,12 +4387,31 @@ Respond ONLY with valid JSON, no other text.`;
       // 使用 activateNotebookManager 确保读取的是当前会话项目的笔记本
       let notebookSummary: string | undefined;
       try {
-        const nbMgr = activateNotebookManager(state.session.cwd) || getNotebookManager();
+        const nbMgr = activateNotebookManager(state.session.cwd) || initNotebookManager(state.session.cwd);
         if (nbMgr) {
           notebookSummary = nbMgr.getNotebookSummaryForPrompt() || undefined;
         }
       } catch {
         // 笔记本加载失败不影响主流程
+      }
+
+      let memoryRecall: string | undefined;
+      try {
+        const recallQuery = this.getLatestUserRecallQuery(state);
+        if (recallQuery && recallQuery.trim().length >= 3) {
+          const embeddingConfig = configManager.get('embedding') as any;
+          const memSearchMgr = await ensureMemorySearchManager(state.session.cwd, embeddingConfig || undefined);
+          const hasCompactSummary = state.messages.some(msg => msg.role === 'user' && msg.isCompactSummary);
+          const recallPlan = await buildLayeredMemoryRecall(memSearchMgr, recallQuery, {
+            sessionId: state.session.sessionId,
+            hasCompactSummary,
+          });
+          memoryRecall = recallPlan.formatted || undefined;
+        }
+      } catch (error) {
+        if (this.options?.verbose || process.env.AXON_DEBUG) {
+          console.warn('[ConversationManager] Failed to refresh memory recall context:', error);
+        }
       }
 
       // autoRecall 已移除：信噪比太低，Notebook 已覆盖有用记忆，用户可主动调用 MemorySearch 工具
@@ -4402,6 +4458,7 @@ Respond ONLY with valid JSON, no other text.`;
           : undefined,
         // Agent 笔记本内容
         notebookSummary,
+        memoryRecall,
         // MCP 服务器信息（用于系统提示中的 MCP 指令）
         mcpServers: mcpServerInfos.length > 0 ? mcpServerInfos : undefined,
         // MCP CLI 模式：通过 Bash 调用 mcp-cli 而非直接注入 MCP 工具定义

--- a/tests/core/auto-memory.test.ts
+++ b/tests/core/auto-memory.test.ts
@@ -290,10 +290,97 @@ describe('ConversationLoop auto memory', () => {
       hasCompactSummary: false,
     }));
 
+    expect(plan.transcriptResults).toHaveLength(0);
     expect(plan.formatted).toContain('[Current session background]');
     expect(plan.formatted).toContain('Session summary keeps current task state.');
     expect(plan.formatted).toContain('[Notebook]');
   }, 15000);
+
+  it('adds transcript recall as past session evidence for the same project', async () => {
+    const loop = new ConversationLoop({
+      workingDir: projectDir,
+      apiKey: 'test-key',
+      model: 'sonnet',
+    }) as any;
+
+    const notebookMgr = getNotebookManagerForProject(projectDir)!;
+    notebookMgr.write(
+      'project',
+      '# Project Notebook\n- recall indexing path bug should first be diagnosed from notebook context.',
+    );
+
+    const projectHash = require('crypto').createHash('md5').update(projectDir).digest('hex').slice(0, 12);
+    await initMemorySearchManager(projectDir, projectHash, undefined);
+
+    const transcriptPath = path.join(configDir, 'sessions', 'past-session.json');
+    fs.mkdirSync(path.dirname(transcriptPath), { recursive: true });
+    fs.writeFileSync(transcriptPath, JSON.stringify({
+      metadata: {
+        id: 'past-session',
+        name: 'Past recall bug fix',
+        createdAt: Date.now() - 7200000,
+        updatedAt: Date.now() - 3600000,
+        workingDirectory: projectDir,
+        projectPath: projectDir,
+        model: 'sonnet',
+      },
+      messages: [
+        { role: 'user', content: 'We hit this recall indexing bug before.' },
+        { role: 'assistant', content: 'The fix was to align the summary indexing path with session-memory storage.' },
+      ],
+    }), 'utf-8');
+
+    await loop.refreshPromptMemoryContext('recall indexing path bug');
+
+    expect(typeof loop.promptContext.memoryRecall).toBe('string');
+    expect(loop.promptContext.memoryRecall).toContain('[Notebook]');
+    expect(loop.promptContext.memoryRecall).toContain('[Past session evidence]');
+    expect(loop.promptContext.memoryRecall).toContain('recall indexing path bug');
+    expect(loop.promptContext.memoryRecall).toContain('The fix');
+  });
+
+  it('does not pull transcript recall from a different project', async () => {
+    const loop = new ConversationLoop({
+      workingDir: projectDir,
+      apiKey: 'test-key',
+      model: 'sonnet',
+    }) as any;
+
+    const notebookMgr = getNotebookManagerForProject(projectDir)!;
+    notebookMgr.write(
+      'project',
+      '# Project Notebook\n- same phrase exists in another project must stay isolated to that project.',
+    );
+
+    const projectHash = require('crypto').createHash('md5').update(projectDir).digest('hex').slice(0, 12);
+    await initMemorySearchManager(projectDir, projectHash, undefined);
+
+    const otherProjectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'axon-other-project-'));
+    const transcriptPath = path.join(configDir, 'sessions', 'other-project-session.json');
+    fs.mkdirSync(path.dirname(transcriptPath), { recursive: true });
+    fs.writeFileSync(transcriptPath, JSON.stringify({
+      metadata: {
+        id: 'other-project-session',
+        name: 'Other project bug',
+        createdAt: Date.now() - 7200000,
+        updatedAt: Date.now() - 3600000,
+        workingDirectory: otherProjectDir,
+        projectPath: otherProjectDir,
+        model: 'sonnet',
+      },
+      messages: [
+        { role: 'user', content: 'This same phrase exists in another project.' },
+        { role: 'assistant', content: 'But it should not be recalled into the current project.' },
+      ],
+    }), 'utf-8');
+
+    await loop.refreshPromptMemoryContext('same phrase exists in another project');
+
+    expect(typeof loop.promptContext.memoryRecall).toBe('string');
+    expect(loop.promptContext.memoryRecall).toContain('[Notebook]');
+    expect(loop.promptContext.memoryRecall).not.toContain('[Past session evidence]');
+    expect(loop.promptContext.memoryRecall).not.toContain('should not be recalled into the current project');
+  });
 
   it('skips session summary recall when compact summary already exists in session messages', async () => {
     const loop = new ConversationLoop({
@@ -302,24 +389,11 @@ describe('ConversationLoop auto memory', () => {
       model: 'sonnet',
     }) as any;
 
-    loop.promptBuilder = {
-      build: vi.fn().mockImplementation(async (context: any) => ({
-        content: 'mock-system-prompt',
-        blocks: [],
-        hashInfo: {
-          hash: 'mock-hash',
-          computedAt: Date.now(),
-          length: 18,
-          estimatedTokens: 5,
-        },
-        attachments: [],
-        truncated: false,
-        buildTimeMs: 1,
-      })),
-    };
-
     const notebookMgr = getNotebookManagerForProject(projectDir)!;
-    notebookMgr.write('project', '# Project Notebook\n- Notebook recall remains available.');
+    notebookMgr.write(
+      'project',
+      '# Project Notebook\n- current task state should come from notebook recall when compact summaries already exist in messages.',
+    );
 
     const summaryPath = getSummaryPath(projectDir, loop.session.sessionId);
     fs.mkdirSync(path.dirname(summaryPath), { recursive: true });
@@ -333,13 +407,7 @@ describe('ConversationLoop auto memory', () => {
       isCompactSummary: true,
     });
 
-    loop.client.createMessage = vi.fn().mockResolvedValue({
-      content: [{ type: 'text', text: '好的' }],
-      stopReason: 'end_turn',
-      usage: { inputTokens: 10, outputTokens: 5 },
-    });
-
-    await loop.processMessage('current task state');
+    await loop.refreshPromptMemoryContext('current task state');
 
     expect(typeof loop.promptContext.memoryRecall).toBe('string');
     expect(loop.promptContext.memoryRecall).toContain('[Notebook]');

--- a/tests/memory/long-term-store-bugs.test.ts
+++ b/tests/memory/long-term-store-bugs.test.ts
@@ -70,6 +70,19 @@ describe('LongTermStore bug fixes', () => {
       // If we got here without error, version migration worked
     });
 
+    it('should recreate the parent directory if it disappears during async initialization', async () => {
+      const dbPath = path.join(tmpDir, 'race', 'nested', 'race.sqlite');
+      const createPromise = LongTermStore.create(dbPath);
+
+      try {
+        fs.rmSync(path.dirname(dbPath), { recursive: true, force: true });
+      } catch {}
+
+      const raceStore = await createPromise;
+      expect(fs.existsSync(path.dirname(dbPath))).toBe(true);
+      raceStore.close();
+    });
+
     it('should handle re-opening existing database', async () => {
       const dbPath = path.join(tmpDir, 'reopen.sqlite');
       const store1 = await LongTermStore.create(dbPath);

--- a/tests/memory/memory-search.test.ts
+++ b/tests/memory/memory-search.test.ts
@@ -159,11 +159,64 @@ describe('MemorySearchManager', () => {
 
       expect(result.notebookResults).toHaveLength(1);
       expect(result.sessionSummaryResults).toHaveLength(1);
+      expect(result.transcriptResults).toHaveLength(0);
       expect(result.formatted).toContain('[Notebook]');
       expect(result.formatted).toContain('[Current session background]');
       expect(result.formatted).toContain('Project notebook says use direct, honest answers.');
       expect(result.formatted).toContain('Current session is evaluating layered recall for summary.md.');
       expect(result.formatted).not.toContain('Other session summary should not appear.');
+    });
+
+    it('adds transcript evidence only as a secondary layer after notebook and current session background', () => {
+      const now = Date.now();
+      const result = planLayeredRecallFromResults([
+        {
+          id: 'nb-1',
+          path: 'notebook:project.md',
+          startLine: 1,
+          endLine: 3,
+          score: 0.9,
+          snippet: 'Project notebook says prefer direct root-cause analysis.',
+          source: 'notebook',
+          timestamp: new Date(now).toISOString(),
+          age: 3600000,
+        },
+        {
+          id: 'ss-1',
+          path: 'session-123/session-memory/summary.md',
+          startLine: 5,
+          endLine: 8,
+          score: 0.7,
+          snippet: 'Current session is debugging layered recall rollout.',
+          source: 'session',
+          timestamp: new Date(now).toISOString(),
+          age: 7200000,
+        },
+        {
+          id: 'tr-1',
+          path: 'transcript:old-session.json',
+          startLine: 12,
+          endLine: 20,
+          score: 0.65,
+          snippet: '# Past session\nDate: 2026-03-20\nModel: sonnet\nProject: /repo\n\n## User\nWe hit the same recall bug before.\n\n## Assistant\nThe fix was to align summary indexing paths.',
+          source: 'session',
+          timestamp: new Date(now).toISOString(),
+          age: 10800000,
+        },
+      ], {
+        sessionId: 'session-123',
+        hasCompactSummary: false,
+        transcriptLimit: 1,
+      });
+
+      expect(result.notebookResults).toHaveLength(1);
+      expect(result.sessionSummaryResults).toHaveLength(1);
+      expect(result.transcriptResults).toHaveLength(1);
+      expect(result.formatted).toContain('[Past session evidence]');
+      expect(result.formatted).toContain('We hit the same recall bug before.');
+      expect(result.formatted).toContain('The fix was to align summary indexing paths.');
+      expect(result.formatted).not.toContain('Project: /repo');
+      expect(result.formatted).not.toContain('## User');
     });
 
     it('skips session summary fallback when compact summary already exists in messages', () => {

--- a/tests/memory/memory-sync-bugs.test.ts
+++ b/tests/memory/memory-sync-bugs.test.ts
@@ -44,6 +44,50 @@ describe('MemorySyncEngine bug fixes', () => {
       expect(matches.some(match => match.path === 'session-1/session-memory/summary.md')).toBe(true);
     });
 
+    it('should index transcript files only for the current project', async () => {
+      const transcriptsDir = path.join(tmpDir, 'sessions');
+      const projectDir = path.join(tmpDir, 'project-a');
+      const otherProjectDir = path.join(tmpDir, 'project-b');
+      fs.mkdirSync(transcriptsDir, { recursive: true });
+
+      const sameProjectTranscript = path.join(transcriptsDir, 'same-project.json');
+      fs.writeFileSync(sameProjectTranscript, JSON.stringify({
+        metadata: {
+          id: 'same-project',
+          workingDirectory: projectDir,
+          projectPath: projectDir,
+          model: 'sonnet',
+          createdAt: Date.now(),
+        },
+        messages: [
+          { role: 'user', content: 'same project transcript evidence' },
+          { role: 'assistant', content: 'useful fix from same project' },
+        ],
+      }), 'utf-8');
+
+      const otherProjectTranscript = path.join(transcriptsDir, 'other-project.json');
+      fs.writeFileSync(otherProjectTranscript, JSON.stringify({
+        metadata: {
+          id: 'other-project',
+          workingDirectory: otherProjectDir,
+          projectPath: otherProjectDir,
+          model: 'sonnet',
+          createdAt: Date.now(),
+        },
+        messages: [
+          { role: 'user', content: 'other project transcript evidence' },
+          { role: 'assistant', content: 'should not leak across projects' },
+        ],
+      }), 'utf-8');
+
+      syncEngine = new MemorySyncEngine(store, { projectDir });
+      const result = await syncEngine.syncTranscriptFiles(transcriptsDir);
+
+      expect(result.added).toBe(1);
+      expect(store.hasFile('transcript:same-project.json')).toBe(true);
+      expect(store.hasFile('transcript:other-project.json')).toBe(false);
+    });
+
     it('should preserve transcript: entries when syncing session files', async () => {
       // Pre-populate store with a transcript entry (as if syncTranscriptFiles ran before)
       const crypto = require('crypto');

--- a/tests/web/server/conversation.test.ts
+++ b/tests/web/server/conversation.test.ts
@@ -1,4 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { initNotebookManager, resetNotebookManager } from '../../../src/memory/notebook.js';
+import { initMemorySearchManager, resetMemorySearchManager } from '../../../src/memory/memory-search.js';
 
 const mockSystemPromptBuild = vi.fn();
 const mockWebAuth = {
@@ -30,7 +35,18 @@ vi.mock('../../../src/prompt/index.js', () => ({
 }));
 
 describe('ConversationManager startup', () => {
+  let tmpConfigDir: string;
+  let tmpProjectDir: string;
+  const originalConfigDir = process.env.AXON_CONFIG_DIR;
+  const originalDisableBuiltinEmbedding = process.env.AXON_DISABLE_BUILTIN_EMBEDDING;
+
   beforeEach(() => {
+    tmpConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), 'axon-web-conversation-'));
+    tmpProjectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'axon-web-project-'));
+    process.env.AXON_CONFIG_DIR = tmpConfigDir;
+    process.env.AXON_DISABLE_BUILTIN_EMBEDDING = '1';
+    resetNotebookManager();
+    resetMemorySearchManager();
     vi.clearAllMocks();
     mockWebAuth.getRuntimeBackend.mockReturnValue('codex-subscription');
     mockWebAuth.getDefaultModelByBackend.mockReturnValue({});
@@ -53,6 +69,23 @@ describe('ConversationManager startup', () => {
       buildTimeMs: 0,
       hashInfo: { estimatedTokens: 0 },
     });
+  });
+
+  afterEach(() => {
+    resetNotebookManager();
+    resetMemorySearchManager();
+    if (originalConfigDir) {
+      process.env.AXON_CONFIG_DIR = originalConfigDir;
+    } else {
+      delete process.env.AXON_CONFIG_DIR;
+    }
+    if (originalDisableBuiltinEmbedding) {
+      process.env.AXON_DISABLE_BUILTIN_EMBEDDING = originalDisableBuiltinEmbedding;
+    } else {
+      delete process.env.AXON_DISABLE_BUILTIN_EMBEDDING;
+    }
+    try { fs.rmSync(tmpConfigDir, { recursive: true, force: true }); } catch {}
+    try { fs.rmSync(tmpProjectDir, { recursive: true, force: true }); } catch {}
   });
 
   it('constructs without recursive runtime resolution on codex backends', async () => {
@@ -134,6 +167,131 @@ describe('ConversationManager startup', () => {
     expect(guidance).toContain('ImageGen tool usage');
     expect(guidance).toContain('edit_strength');
     expect(guidance).toContain('image attachment edit preferences');
+  });
+
+  it('injects layered memory recall into web system prompts for the active project', async () => {
+    const { ConversationManager } = await import('../../../src/web/server/conversation.js');
+    const manager = new ConversationManager(tmpProjectDir, 'opus') as any;
+
+    const notebookMgr = initNotebookManager(tmpProjectDir);
+    notebookMgr.write('project', '# Project Notebook\n- recall indexing path bug should first be diagnosed from notebook context.');
+    await initMemorySearchManager(tmpProjectDir, require('crypto').createHash('md5').update(tmpProjectDir).digest('hex').slice(0, 12), undefined);
+
+    const transcriptPath = path.join(tmpConfigDir, 'sessions', 'past-session.json');
+    fs.mkdirSync(path.dirname(transcriptPath), { recursive: true });
+    fs.writeFileSync(transcriptPath, JSON.stringify({
+      metadata: {
+        id: 'past-session',
+        projectPath: tmpProjectDir,
+        workingDirectory: tmpProjectDir,
+        model: 'sonnet',
+        createdAt: Date.now() - 60000,
+      },
+      messages: [
+        { role: 'user', content: 'We hit this recall indexing bug before.' },
+        { role: 'assistant', content: 'The fix was to align the summary indexing path with session-memory storage.' },
+      ],
+    }), 'utf-8');
+
+    manager.sessions.set('memory-session', {
+      session: { cwd: tmpProjectDir, sessionId: 'memory-session' },
+      client: {},
+      messages: [{ role: 'user', content: 'recall indexing path bug' }],
+      model: 'sonnet',
+      runtimeBackend: 'codex-subscription',
+      cancelled: false,
+      chatHistory: [],
+      userInteractionHandler: {},
+      taskManager: {},
+      permissionHandler: {},
+      rewindManager: {},
+      toolFilterConfig: { mode: 'all' },
+      systemPromptConfig: { useDefault: true },
+      isProcessing: false,
+      processingGeneration: 0,
+      lastActualInputTokens: 0,
+      messagesLenAtLastApiCall: 0,
+      pendingContinuationAfterRestore: false,
+      latestImageAttachments: [],
+      lastPersistedMessageCount: 1,
+    });
+
+    await manager.getSystemPrompt('memory-session');
+
+    const context = mockSystemPromptBuild.mock.calls.at(-1)?.[0];
+    expect(context.notebookSummary).toContain('recall indexing path bug');
+    expect(context.memoryRecall).toContain('[Notebook]');
+    expect(context.memoryRecall).toContain('[Past session evidence]');
+    expect(context.memoryRecall).toContain('The fix');
+  });
+
+  it('uses per-project memory search manager for web sessions', async () => {
+    const { ConversationManager } = await import('../../../src/web/server/conversation.js');
+    const otherProjectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'axon-web-project-other-'));
+    const manager = new ConversationManager(tmpProjectDir, 'opus') as any;
+
+    initNotebookManager(tmpProjectDir).write('project', '# Project Notebook\n- alpha bug belongs to project alpha.');
+    initNotebookManager(otherProjectDir).write('project', '# Project Notebook\n- beta bug belongs to project beta.');
+    await initMemorySearchManager(tmpProjectDir, require('crypto').createHash('md5').update(tmpProjectDir).digest('hex').slice(0, 12), undefined);
+    await initMemorySearchManager(otherProjectDir, require('crypto').createHash('md5').update(otherProjectDir).digest('hex').slice(0, 12), undefined);
+
+    manager.sessions.set('project-alpha', {
+      session: { cwd: tmpProjectDir, sessionId: 'project-alpha' },
+      client: {},
+      messages: [{ role: 'user', content: 'alpha bug' }],
+      model: 'sonnet',
+      runtimeBackend: 'codex-subscription',
+      cancelled: false,
+      chatHistory: [],
+      userInteractionHandler: {},
+      taskManager: {},
+      permissionHandler: {},
+      rewindManager: {},
+      toolFilterConfig: { mode: 'all' },
+      systemPromptConfig: { useDefault: true },
+      isProcessing: false,
+      processingGeneration: 0,
+      lastActualInputTokens: 0,
+      messagesLenAtLastApiCall: 0,
+      pendingContinuationAfterRestore: false,
+      latestImageAttachments: [],
+      lastPersistedMessageCount: 1,
+    });
+
+    manager.sessions.set('project-beta', {
+      session: { cwd: otherProjectDir, sessionId: 'project-beta' },
+      client: {},
+      messages: [{ role: 'user', content: 'beta bug' }],
+      model: 'sonnet',
+      runtimeBackend: 'codex-subscription',
+      cancelled: false,
+      chatHistory: [],
+      userInteractionHandler: {},
+      taskManager: {},
+      permissionHandler: {},
+      rewindManager: {},
+      toolFilterConfig: { mode: 'all' },
+      systemPromptConfig: { useDefault: true },
+      isProcessing: false,
+      processingGeneration: 0,
+      lastActualInputTokens: 0,
+      messagesLenAtLastApiCall: 0,
+      pendingContinuationAfterRestore: false,
+      latestImageAttachments: [],
+      lastPersistedMessageCount: 1,
+    });
+
+    await manager.getSystemPrompt('project-alpha');
+    const alphaContext = mockSystemPromptBuild.mock.calls.at(-1)?.[0];
+    expect(alphaContext.notebookSummary).toContain('alpha bug belongs to project alpha');
+    expect(alphaContext.notebookSummary).not.toContain('beta bug belongs to project beta');
+
+    await manager.getSystemPrompt('project-beta');
+    const betaContext = mockSystemPromptBuild.mock.calls.at(-1)?.[0];
+    expect(betaContext.notebookSummary).toContain('beta bug belongs to project beta');
+    expect(betaContext.notebookSummary).not.toContain('alpha bug belongs to project alpha');
+
+    try { fs.rmSync(otherProjectDir, { recursive: true, force: true }); } catch {}
   });
 
   it('maps assistant thinking blocks into Web chat history', async () => {


### PR DESCRIPTION
Wire transcript-backed layered recall into the web conversation path, keep memory search managers isolated per project, and prevent transcript indexing from mixing data across projects. Also harden long-term store initialization against temp-directory races so memory search setup stops emitting noisy failures in tests.

## Summary

<!-- What does this PR do? Keep it concise. -->

## Changes

- 

## Related Issue

<!-- Link to the issue this PR addresses, e.g., Fixes #123 -->

## Testing

- [ ] `npx tsc --noEmit` passes
- [ ] `npm test -- --run` passes
- [ ] Manually tested in CLI mode
- [ ] Manually tested in Web UI mode

## Screenshots

<!-- If applicable, add screenshots or GIFs -->
